### PR TITLE
Add syntax highlighting to the readme's code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,26 +25,28 @@ pub transformer available in this package.
 
 A simple usage example:
 
-    import 'package:reflectable/reflectable.dart';
+```dart
+import 'package:reflectable/reflectable.dart';
 
-    class MyReflectable extends Reflectable {
-      const MyReflectable():
-          super(/* ..constrain, but do not prevent invoke on #foo.. */);
-    }
+class MyReflectable extends Reflectable {
+  const MyReflectable():
+      super(/* ..constrain, but do not prevent invoke on #foo.. */);
+}
 
-    const myReflectable = const MyReflectable;
+const myReflectable = const MyReflectable;
 
-    @myReflectable
-    class MyClass { ... bool foo(int x) {..} ... }
+@myReflectable
+class MyClass { ... bool foo(int x) {..} ... }
 
-    main() {
-      var x = new MyClass();
-      // Normal invocation.
-      x.foo(3);
-      // Reflectable invocation.
-      var xr = myReflectable.reflect(x);
-      xr.invoke(#foo, [3]);
-    }
+main() {
+  var x = new MyClass();
+  // Normal invocation.
+  x.foo(3);
+  // Reflectable invocation.
+  var xr = myReflectable.reflect(x);
+  xr.invoke(#foo, [3]);
+}
+```
 
 ## Features and bugs
 


### PR DESCRIPTION
Github has a neat feature with triple-backtick code blocks, where you can specify the language name and get syntax highlighting:
https://help.github.com/articles/github-flavored-markdown/#syntax-highlighting