### PR TITLE
Add isEnum to reflectable ClassMirror

### DIFF
--- a/reflectable/lib/mirrors.dart
+++ b/reflectable/lib/mirrors.dart
@@ -333,6 +333,12 @@ abstract class ClassMirror implements TypeMirror, ObjectMirror {
   ClassMirror get superclass;
   List<ClassMirror> get superinterfaces;
   bool get isAbstract;
+
+  /**
+   * Is the reflectee an enum?
+   */
+  bool get isEnum;
+
   // The non-abstract members declared in this class.
   Map<String, DeclarationMirror> get declarations;
   Map<String, MethodMirror> get instanceMembers;

--- a/reflectable/lib/src/reflectable_mirror_based.dart
+++ b/reflectable/lib/src/reflectable_mirror_based.dart
@@ -821,6 +821,9 @@ class ClassMirrorImpl extends _TypeMirrorImpl
   }
 
   bool get _isMixin => _classMirror.mixin != _classMirror;
+
+  @override
+  bool get isEnum => _classMirror.isEnum;
 }
 
 class _FunctionTypeMirrorImpl extends ClassMirrorImpl

--- a/reflectable/lib/src/reflectable_transformer_based.dart
+++ b/reflectable/lib/src/reflectable_transformer_based.dart
@@ -498,6 +498,10 @@ class ClassMirrorImpl extends _DataCaching implements ClassMirror {
   // Because we take care to only ever create one instance for each
   // type/reflector-combination we can rely on the default `hashCode` and `==`
   // operations.
+
+  // TODO: implement isEnum
+  @override
+  bool get isEnum => _unsupported();
 }
 
 class LibraryMirrorImpl extends _DataCaching implements LibraryMirror {


### PR DESCRIPTION
Add the `isEnum` method to reflectable `ClassMirror` class. In this way we will be able to check if the object is an enum