### PR TITLE
Include dart_style 1.x.x as dependency

### DIFF
--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   analyzer: '>=0.27.2 <0.30.0'
   barback: ^0.15.0
   code_transformers: '>=0.4.1 <0.6.0'
-  dart_style: ^0.2.0
+  dart_style: ">=0.2.0 <2.0.0"
   glob: ^1.1.0
   logging: ^0.11.0
   path: ^1.2.0


### PR DESCRIPTION
I haven't seen a reason not to include it, and it solves a lot of dependency conflicts for me.