### PR TITLE
Add glob dec17

### DIFF
--- a/coverage_reflectable/pubspec.yaml
+++ b/coverage_reflectable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: coverage_reflectable
-version: 2.0.0-dev.1.0
+version: 2.0.0-dev.2.0
 description: >
   A simple tool for measuring code coverage in the reflectable transformer when
   transforming all tests in 'test_reflectable/test'. Only useful for developers

--- a/reflectable/lib/reflectable_builder.dart
+++ b/reflectable/lib/reflectable_builder.dart
@@ -13,7 +13,7 @@ import 'package:reflectable/transformer.dart';
 Future<BuildResult> reflectableBuild(List<String> arguments) async {
   if (arguments.length < 1) {
     // Globbing may produce an empty argument list, and it might be ok,
-    // but we should give at least give notify the caller.
+    // but we should give at least notify the caller.
     print("reflectable_builder: No arguments given, exiting.");
     return new BuildResult(BuildStatus.success, []);
   } else {

--- a/reflectable/lib/reflectable_builder.dart
+++ b/reflectable/lib/reflectable_builder.dart
@@ -30,6 +30,7 @@ Future<BuildResult> reflectableBuild(List<String> arguments) async {
       const <String, List<String>>{'.dart': const ['.reflectable.dart']},
     );
     return await build(
-        [new BuildAction(builder, packageName, inputs: arguments)]);
+        [new BuildAction(builder, packageName, inputs: arguments)],
+        deleteFilesByDefault: true);
   }
 }

--- a/reflectable/lib/reflectable_builder.dart
+++ b/reflectable/lib/reflectable_builder.dart
@@ -4,14 +4,18 @@
 
 library reflectable.src.reflectable_builder;
 
+import 'dart:async';
 import 'package:barback/src/transformer/barback_settings.dart';
 import 'package:build_barback/build_barback.dart';
 import 'package:build_runner/build_runner.dart';
 import 'package:reflectable/transformer.dart';
 
-reflectableBuild(List<String> arguments) async {
+Future<BuildResult> reflectableBuild(List<String> arguments) async {
   if (arguments.length < 1) {
-    print("reflectable_builder: Expects ");
+    // Globbing may produce an empty argument list, and it might be ok,
+    // but we should give at least give notify the caller.
+    print("reflectable_builder: No arguments given, exiting.");
+    return new BuildResult(BuildStatus.success, []);
   } else {
     PackageGraph graph = new PackageGraph.forThisPackage();
     String packageName = graph.root.name;
@@ -25,6 +29,7 @@ reflectableBuild(List<String> arguments) async {
       new ReflectableTransformer.asPlugin(settings),
       const <String, List<String>>{'.dart': const ['.reflectable.dart']},
     );
-    await build([new BuildAction(builder, packageName, inputs: arguments)]);
+    return await build(
+        [new BuildAction(builder, packageName, inputs: arguments)]);
   }
 }

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -1,4 +1,5 @@
 name: reflectable
+version: 2.0.0-dev.2.0
 description: >
   This package allows programmers to reduce certain usages of dynamic
   reflection to a statically specified subset thereof, based on generated

--- a/test_reflectable/pubspec.yaml
+++ b/test_reflectable/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   reflectable:
     path: ../reflectable
   build_runner: ^0.6.1
+  glob: ^1.1.5
 dev_dependencies:
   unittest: ^0.11.0
 transformers:

--- a/test_reflectable/pubspec.yaml
+++ b/test_reflectable/pubspec.yaml
@@ -1,8 +1,8 @@
 name: test_reflectable
+version: 2.0.0-dev.2.0
 description: >
   This package contains tests which depend on package reflectable
   and which are transformed by the transformer in that package.
-version: 2.0.0-dev.1.0
 author: The Dart Team <dart@google.com>
 homepage: https://www.github.com/dart-lang/reflectable
 environment:

--- a/test_reflectable/tool/build.dart
+++ b/test_reflectable/tool/build.dart
@@ -2,8 +2,16 @@
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
+import 'package:glob/glob.dart';
 import 'package:reflectable/reflectable_builder.dart' as builder;
 
 main(List<String> arguments) async {
-  await builder.reflectableBuild(arguments);
+  List<String> globbedArguments = <String>[];
+  for (String argument in arguments) {
+    String fileSpec = new Glob(argument);
+    await for (FileSystemEntity entity in fileSpec.list()) {
+      globbedArguments.add(entity.path);
+    }
+  }
+  await builder.reflectableBuild(globbedArguments);
 }

--- a/test_reflectable/tool/build.dart
+++ b/test_reflectable/tool/build.dart
@@ -9,9 +9,11 @@ import 'package:reflectable/reflectable_builder.dart' as builder;
 main(List<String> arguments) async {
   List<String> globbedArguments = <String>[];
   for (String argument in arguments) {
-    Glob fileSpec = new Glob(argument);
-    await for (var entity in fileSpec.list()) {
-      globbedArguments.add(entity.path);
+    Glob fileGlob = new Glob(argument);
+    await for (var entity in fileGlob.list()) {
+      String fileSpec = entity.path;
+      if (fileSpec.startsWith("./")) fileSpec = fileSpec.substring(2);
+      globbedArguments.add(fileSpec);
     }
   }
   return await builder.reflectableBuild(globbedArguments) ==

--- a/test_reflectable/tool/build.dart
+++ b/test_reflectable/tool/build.dart
@@ -2,16 +2,18 @@
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
+import 'package:build_runner/build_runner.dart';
 import 'package:glob/glob.dart';
 import 'package:reflectable/reflectable_builder.dart' as builder;
 
 main(List<String> arguments) async {
   List<String> globbedArguments = <String>[];
   for (String argument in arguments) {
-    String fileSpec = new Glob(argument);
-    await for (FileSystemEntity entity in fileSpec.list()) {
+    Glob fileSpec = new Glob(argument);
+    await for (var entity in fileSpec.list()) {
       globbedArguments.add(entity.path);
     }
   }
-  await builder.reflectableBuild(globbedArguments);
+  return await builder.reflectableBuild(globbedArguments) ==
+      BuildStatus.success;
 }


### PR DESCRIPTION
Turns out that the previous version looked OK, but a failure was masked (so nothing was built, but no information about the failure was returned so `annotated_steps.dart` thought it was all ok). This CL pushes the result information through the pipeline, and also solves the original problem by globbing the arguments given to build.dart.