### PR TITLE
Absolute paths dec17

### DIFF
--- a/tool/annotated_steps.dart
+++ b/tool/annotated_steps.dart
@@ -33,6 +33,7 @@ runBuildScriptInSubdirectory(String subdirectory) async {
   String buildScriptPath = packageUri
       .resolve(subdirectory + Platform.pathSeparator + "tool/build.dart")
       .toFilePath();
+  String workingDirectory = packageUri.resolve(subdirectory).toFilePath();
   String argument = packageUri
       .resolve(
           [subdirectory, "test", "*_test.dart"].join(Platform.pathSeparator))
@@ -41,6 +42,7 @@ runBuildScriptInSubdirectory(String subdirectory) async {
   Process process = await Process.start(
     dartPath,
     [buildScriptPath, argument],
+    workingDirectory: workingDirectory,
     environment: environment,
   );
   stdout.addStream(process.stdout);

--- a/tool/annotated_steps.dart
+++ b/tool/annotated_steps.dart
@@ -33,16 +33,14 @@ runBuildScriptInSubdirectory(String subdirectory) async {
   String buildScriptPath = packageUri
       .resolve(subdirectory + Platform.pathSeparator + "tool/build.dart")
       .toFilePath();
-  String argument = "test" + Platform.pathSeparator + "*_test.dart";
-  String workingDirectory = packageUri.resolve(subdirectory).toFilePath();
-  packageUri
-      .resolve(subdirectory + Platform.pathSeparator + "tool/build.dart")
+  String argument = packageUri
+      .resolve(
+          [subdirectory, "test", "*_test.dart"].join(Platform.pathSeparator))
       .toFilePath();
   print("^^^^^^^ Running $buildScriptPath for $subdirectory");
   Process process = await Process.start(
     dartPath,
     [buildScriptPath, argument],
-    workingDirectory: workingDirectory,
     environment: environment,
   );
   stdout.addStream(process.stdout);

--- a/tool/annotated_steps.dart
+++ b/tool/annotated_steps.dart
@@ -33,11 +33,11 @@ runBuildScriptInSubdirectory(String subdirectory) async {
   String buildScriptPath = packageUri
       .resolve(subdirectory + Platform.pathSeparator + "tool/build.dart")
       .toFilePath();
-  String workingDirectory = packageUri.resolve(subdirectory).toFilePath();
   String argument = packageUri
       .resolve(
           [subdirectory, "test", "*_test.dart"].join(Platform.pathSeparator))
       .toFilePath();
+  String workingDirectory = packageUri.resolve(subdirectory).toFilePath();
   print("^^^^^^^ Running $buildScriptPath for $subdirectory");
   Process process = await Process.start(
     dartPath,


### PR DESCRIPTION
Still getting 'ProcessException: No such file or directory' on the package bot even though it's running locally. This CL just changes the file arguments to `build.dart` to use absolute paths.