### PR TITLE
update to latest package:build and add custom build.yaml

### DIFF
--- a/reflectable/build.yaml
+++ b/reflectable/build.yaml
@@ -1,0 +1,11 @@
+builders:
+  reflectable:
+    target: ":reflectable"
+    import: "package:reflectable/reflectable_builder.dart"
+    builder_factories: ["reflectableBuilder"]
+    build_extensions: {".dart": [".reflectable.dart"]}
+    auto_apply: root_package
+    defaults:
+      generate_for:
+        exclude:
+        - lib/**.dart

--- a/reflectable/lib/reflectable_builder.dart
+++ b/reflectable/lib/reflectable_builder.dart
@@ -6,9 +6,22 @@ library reflectable.src.reflectable_builder;
 
 import 'dart:async';
 import 'package:barback/src/transformer/barback_settings.dart';
+import 'package:build/build.dart';
+import 'package:build_config/build_config.dart';
 import 'package:build_barback/build_barback.dart';
 import 'package:build_runner/build_runner.dart';
 import 'package:reflectable/transformer.dart';
+
+TransformerBuilder reflectableBuilder(BuilderOptions options) {
+  var config = new Map<String, Object>.from(options.config);
+  config.putIfAbsent('entry_points', () => ['**.dart']);
+  return new TransformerBuilder(
+      new ReflectableTransformer.asPlugin(
+          new BarbackSettings(config, BarbackMode.DEBUG)),
+      const <String, List<String>>{
+        '.dart': const ['.reflectable.dart']
+      });
+}
 
 Future<BuildResult> reflectableBuild(List<String> arguments) async {
   if (arguments.length < 1) {
@@ -17,8 +30,6 @@ Future<BuildResult> reflectableBuild(List<String> arguments) async {
     print("reflectable_builder: No arguments given, exiting.");
     return new BuildResult(BuildStatus.success, []);
   } else {
-    PackageGraph graph = new PackageGraph.forThisPackage();
-    String packageName = graph.root.name;
     // TODO(eernst) feature: We should support some customization of
     // the settings, e.g., specifying options like `suppress_warnings`.
     BarbackSettings settings = new BarbackSettings(
@@ -27,10 +38,12 @@ Future<BuildResult> reflectableBuild(List<String> arguments) async {
     );
     final builder = new TransformerBuilder(
       new ReflectableTransformer.asPlugin(settings),
-      const <String, List<String>>{'.dart': const ['.reflectable.dart']},
+      const <String, List<String>>{
+        '.dart': const ['.reflectable.dart']
+      },
     );
     return await build(
-        [new BuildAction(builder, packageName, inputs: arguments)],
+        [applyToRoot(builder, generateFor: new InputSet(include: arguments))],
         deleteFilesByDefault: true);
   }
 }

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -15,8 +15,9 @@ dependencies:
   analyzer: ^0.30.0
   barback: ^0.15.0
   build: ^0.11.1
-  build_barback: ^0.4.0
-  build_runner: ^0.6.1
+  build_barback: ^0.5.0
+  build_config: ^0.2.0
+  build_runner: ^0.7.0
   code_transformers: '>=0.4.1 <0.6.0'
   dart_style: '>=0.2.0 <2.0.0'
   glob: ^1.1.0

--- a/test_reflectable/build.yaml
+++ b/test_reflectable/build.yaml
@@ -1,0 +1,6 @@
+targets:
+  test_reflectable:
+    builders:
+      reflectable:
+        generate_for:
+        - test/**_test.dart

--- a/test_reflectable/pubspec.yaml
+++ b/test_reflectable/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   reflectable:
     path: ../reflectable
-  build_runner: ^0.6.1
+  build_runner: ^0.7.0
   glob: ^1.1.5
 dev_dependencies:
   unittest: ^0.11.0


### PR DESCRIPTION
Here is an example of moving reflectable to the new package:build_runner config.

After this cl, most users of package:reflectable need only do `pub run build_runner build`, and reflectable will automatically bootstrap their application. They would still need to know to include the reflectable.dart file instead of the original one though.

 We have some rough docs [here](https://github.com/dart-lang/build/tree/master/build_config#defining-builders-to-apply-to-dependents-similar-to-transformers) describing what this all does and are working on better ones.

See the example build.yaml I added to the test_reflectable package as well. Users can use the `generate_for` argument to change the primary inputs for the builder using that (this would be similar to the arguments the current build script accepts).

Let me know if you have any questions!