### PR TITLE
Dart 2 fixes

### DIFF
--- a/reflectable/lib/capability.dart
+++ b/reflectable/lib/capability.dart
@@ -475,7 +475,7 @@ class _AdmitSubtypeCapability implements ReflecteeQuantifyCapability {
 
 /// Thrown when reflection is invoked without sufficient capabilities.
 abstract class NoSuchCapabilityError extends Error {
-  factory NoSuchCapabilityError(message) = _NoSuchCapabilityErrorImpl;
+  factory NoSuchCapabilityError(String message) = _NoSuchCapabilityErrorImpl;
 }
 
 class _NoSuchCapabilityErrorImpl extends Error

--- a/reflectable/lib/src/incompleteness.dart
+++ b/reflectable/lib/src/incompleteness.dart
@@ -21,7 +21,7 @@ class UnreachableError extends Error {
 /// `throw unreachableError(..)`, which will indicate to the compiler that this
 /// expression throws (even though it actually happens here). This way we avoid
 /// warnings about a missing return problem, and the code may be more readable.
-void unreachableError(String message) {
+Null unreachableError(String message) {
   String extendedMessage =
       "*** Unexpected situation encountered!\nPlease report a bug on "
       "github.com/dart-lang/reflectable: $message.";
@@ -33,7 +33,7 @@ void unreachableError(String message) {
 /// this expression throws (even though it actually happens here). This way we
 /// avoid warnings about a missing return problem, and the code may be more
 /// readable.
-void unimplementedError(String message) {
+Null unimplementedError(String message) {
   String extendedMessage = "*** Unfortunately, this feature has not yet been "
       "implemented: $message.\n"
       "If you wish to ensure that it is prioritized, please report it "

--- a/reflectable/lib/src/transformer_implementation.dart
+++ b/reflectable/lib/src/transformer_implementation.dart
@@ -239,8 +239,22 @@ class ClassElementEnhancedSet implements Set<ClassElement> {
       classElements.items.map<T>(f);
 
   @override
+  Set<R> cast<R>() {
+    Iterable<Object> self = this;
+    return self is Iterable<R> ? self : Set.castFrom<ClassElement, R>(this);
+  }
+
+  @override
+  Set<R> retype<R>() => unimplementedError("`retype` is not supported");
+
+  @override
   Iterable<ClassElement> where(bool f(ClassElement element)) {
     return classElements.items.where(f);
+  }
+
+  @override
+  Iterable<T> whereType<T>() sync* {
+    for (var element in this) if (element is T) yield (element as T);
   }
 
   @override
@@ -302,6 +316,12 @@ class ClassElementEnhancedSet implements Set<ClassElement> {
   }
 
   @override
+  Iterable<ClassElement> followedBy(Iterable<ClassElement> other) sync* {
+    yield* this;
+    yield* other;
+  }
+
+  @override
   ClassElement get first => classElements.items.first;
 
   @override
@@ -323,7 +343,8 @@ class ClassElementEnhancedSet implements Set<ClassElement> {
   }
 
   @override
-  ClassElement singleWhere(bool test(ClassElement element)) {
+  ClassElement singleWhere(bool test(ClassElement element),
+      {ClassElement orElse()}) {
     return classElements.items.singleWhere(test);
   }
 


### PR DESCRIPTION
This PR introduces new methods in `ClassElementEnhancedSet` such that it again implements `Set<ClassElement>`. It also solves some typing issues arising because of new rules around `void`.