### PR TITLE
Remove .test_config

### DIFF
--- a/.test_config
+++ b/.test_config
@@ -1,3 +1,0 @@
-{
-  "use_custom_script": "$dart $project_root/tool/annotated_steps.dart $python"
-}


### PR DESCRIPTION
Turns out that the execution of the custom script `tool/annotated_steps.dart` is controlled by `.test_config`. This CL removes `.test_config` such that we revert to a standard test run performed by `annotated_steps.py`.