### PR TITLE
Adjusted .status to match the new directory structure

### DIFF
--- a/.status
+++ b/.status
@@ -6,10 +6,10 @@ test/*: SkipByDesign # Testing in build to get a package root.
 
 # Prevent execution of non-test files with name *_test.dart in packages.
 build/test/packages: SkipByDesign
-build/test/mock_tests/packages: SkipByDesign
+build/test/packages: SkipByDesign
 
 [ $runtime != vm ]
-build/test/mock_tests/*: SkipByDesign # Use dart:io.
+build/test/*: SkipByDesign # Use dart:io.
 
 [ $system == windows ]
-build/test/mock_tests/*: RuntimeError # Issue 97.
+build/test/*: RuntimeError # Issue 97.


### PR DESCRIPTION
TBR: During the 'flattening' of reflectable, the test files were moved from `test/mock_tests` to `test`. This CL updates `.status` to match that change.