### PR TITLE
Update reflectable such that test_reflectable can run tests using `pub run build_runner test`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,7 @@
-.idea
-.pub
-pubspec.lock
-reflectable.iml
-build
-packages
-test/packages
 .packages
+.dart_tool
+pubspec.lock
+build
+reflectable.iml
+.idea
 *.reflectable.dart

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2.0.0-dev.3.0
+
+* Now supports client packages using commands like
+  `pub run build_runner test` to generate code and run tests.
+* Added support for generating code to obtain the `Type` value
+  of function types (including the new inline function types like
+  `String Function(int)`).
+* Fixed bugs associated with error handling: In several situations
+  where the build process would get stuck indefinitely, it will 
+  now terminate with the intended error message.
+
 ## 2.0.0-dev.2.0
 
 * Removed bin/reflectable_transformer.dart, which is obsolete.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 * Fixed bugs associated with error handling: In several situations
   where the build process would get stuck indefinitely, it will 
   now terminate with the intended error message.
+* Added note to README.md that generated code should not be published
+  (it should be regenerated, such that it matches the current version of
+  all dependencies).
 
 ## 2.0.0-dev.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 * Added note to README.md that generated code should not be published
   (it should be regenerated, such that it matches the current version of
   all dependencies).
+* Added 'dart:ui' to the set of platform libraries that reflectable will
+  recognize (and potentially import). This will only work on Flutter,
+  but there would not be any references to 'dart:ui' for any non-Flutter
+  program, unless it is already broken in other ways.
 
 ## 2.0.0-dev.2.0
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,13 @@ library whose file name is obtained by taking the file name of the main
 library of the program and adding `.reflectable`. In the example, this
 amounts to `import 'main.reflectable.dart'`.
 
+Note that it is **not recommended to publish generated code**, i.e.,
+published packages on `pub.dartlang.org` should not include files whose
+name is of the form `*.reflectable.dart`. The reason for this is that the
+generated code may change because some direct or indirect dependency
+changes (say, your package indirectly imports package `path` and then
+`path` changes), and this could make some generated code invalid.
+
 It is also necessary to **initialize the reflection support** by calling
 `initializeReflectable()`, as shown at the beginning of `main` in the
 example.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ reflectable **capability**. For a more detailed discussion about
 capabilities, please consult the [reflectable capability design
 document][1]. On this page we just use a couple of simple special cases.
 
-[1]: https://github.com/dart-lang/reflectable/blob/master/reflectable/doc/TheDesignOfReflectableCapabilities.md
+[1]: https://github.com/dart-lang/reflectable/blob/master/doc/TheDesignOfReflectableCapabilities.md
 
 This package uses code generation to provide support for reflection at the
 level which is specified using capabilities. The [`build` package][2] is
@@ -197,10 +197,9 @@ libraries it imports, which illustrates how reflectable can be used to
 dynamically make a choice among several kinds of reflection, and how to
 eliminate several kinds of static dependencies among libraries.
 
-[3]: https://github.com/dart-lang/reflectable/blob/master/test_reflectable/tool/reflectable_transformer
-[4]: https://github.com/dart-lang/reflectable/blob/master/test_reflectable/test/serialize_test.dart
-[5]: https://github.com/dart-lang/reflectable/blob/master/test_reflectable/lib/serialize.dart
-[6]: https://github.com/dart-lang/reflectable/blob/master/test_reflectable/test/meta_reflectors_test.dart
+[4]: https://github.com/dart-lang/test_reflectable/tree/master/test/serialize_test.dart
+[5]: https://github.com/dart-lang/test_reflectable/tree/master/lib/serialize.dart
+[6]: https://github.com/dart-lang/test_reflectable/tree/master/test/meta_reflectors_test.dart
 
 
 ## Known limitations

--- a/README.md
+++ b/README.md
@@ -207,7 +207,8 @@ following parts are still incomplete:
   `typedef` it is possible to use that name as a type annotation, say, on a
   method parameter or as a return type, and then `reflectedTypeCapability`
   will make it possible to get a corresponding `reflectedType` and
-  `dynamicReflectedType`.
+  `dynamicReflectedType`. For non-generic function types this will also
+  work with anonymous (inline) function types like `void Function(int)`.
 
 - Private declarations. There is currently almost no support for reflection
   on private declarations, as this would require special support from the

--- a/build.yaml
+++ b/build.yaml
@@ -5,6 +5,7 @@ builders:
     builder_factories: ["reflectableBuilder"]
     build_extensions: {".dart": [".reflectable.dart"]}
     auto_apply: root_package
+    build_to: source
     defaults:
       generate_for:
         exclude:

--- a/lib/src/transformer_implementation.dart
+++ b/lib/src/transformer_implementation.dart
@@ -4376,6 +4376,7 @@ Set<String> sdkLibraryNames = new Set.from([
   "profiler",
   "svg",
   "typed_data",
+  "ui",
   "web_audio",
   "web_gl",
   "web_sql"

--- a/lib/src/transformer_implementation.dart
+++ b/lib/src/transformer_implementation.dart
@@ -375,7 +375,8 @@ class ClassElementEnhancedSet implements Set<ClassElement> {
     bool result = classElements.add(value);
     if (result) {
       assert(!elementToDomain.containsKey(value));
-      elementToDomain[value] = _createClassDomain(value, reflectorDomain, reflectorDomain._logger);
+      elementToDomain[value] =
+          _createClassDomain(value, reflectorDomain, reflectorDomain._logger);
       if (value is MixinApplication && value.subclass != null) {
         // [value] is a mixin application which is the immediate superclass
         // of a class which is a regular class (not a mixin application). This
@@ -806,7 +807,8 @@ class _ReflectorDomain {
     /// for importability and insertion into [importCollector] to have taken
     /// place already.
     void uncheckedAddLibrary(LibraryElement library) {
-      _LibraryDomain libraryDomain = _createLibraryDomain(library, this, logger);
+      _LibraryDomain libraryDomain =
+          _createLibraryDomain(library, this, logger);
       libraries.add(libraryDomain);
       libraryMap[library] = libraryDomain;
       libraryDomain._declarations.forEach(members.add);
@@ -1271,7 +1273,7 @@ class _ReflectorDomain {
     String instanceMembersCode = "null";
     if (_capabilities._impliesDeclarations) {
       instanceMembersCode = _formatAsConstList("int",
-                                               classDomain._instanceMembers.map((ExecutableElement element) {
+          classDomain._instanceMembers.map((ExecutableElement element) {
         // TODO(eernst) implement: The "magic" default constructor has
         // index: NO_CAPABILITY_INDEX; adjust this when support for it has
         // been implemented.
@@ -1308,7 +1310,7 @@ class _ReflectorDomain {
       superclassIndex =
           (classElement is! MixinApplication && classElement.type.isObject)
               ? "null"
-          : (classes.contains(superclass))
+              : (classes.contains(superclass))
                   ? "${classes.indexOf(superclass)}"
                   : "${constants.NO_CAPABILITY_INDEX}";
     }
@@ -1353,9 +1355,9 @@ class _ReflectorDomain {
           ? classes.indexOf(classElement.mixins.last.element)
           : (classElement is MixinApplication
               // Anonymous mixin application.
-             ? classes.indexOf(classElement.mixin)
+              ? classes.indexOf(classElement.mixin)
               // No mixins, by convention we use the class itself.
-             : classes.indexOf(classElement));
+              : classes.indexOf(classElement));
       // We may not have support for the given class, in which case we must
       // correct the `null` from `indexOf` to indicate missing capability.
       if (mixinIndex == null) mixinIndex = constants.NO_CAPABILITY_INDEX;
@@ -1372,8 +1374,8 @@ class _ReflectorDomain {
           'int',
           classElement.interfaces
               .map((InterfaceType type) => type.element)
-          .where(classes.contains)
-          .map(classes.indexOf));
+              .where(classes.contains)
+              .map(classes.indexOf));
     }
 
     String classMetadataCode;
@@ -1838,7 +1840,8 @@ class _ReflectorDomain {
           }
         }
         String returnType = _typeCodeOfTypeArgument(dartType.returnType,
-                                                    importCollector, typeVariablesInScope, typedefs, logger, useNameOfGenericFunctionType: useNameOfGenericFunctionType);
+            importCollector, typeVariablesInScope, typedefs, logger,
+            useNameOfGenericFunctionType: useNameOfGenericFunctionType);
         String typeArguments = "";
         if (!dartType.typeFormals.isEmpty) {
           List<String> typeArgumentList = dartType.typeFormals.map(
@@ -1852,7 +1855,9 @@ class _ReflectorDomain {
                   parameterType,
                   importCollector,
                   typeVariablesInScope,
-                  typedefs, logger, useNameOfGenericFunctionType: useNameOfGenericFunctionType));
+                  typedefs,
+                  logger,
+                  useNameOfGenericFunctionType: useNameOfGenericFunctionType));
           argumentTypes = normalParameterTypeList.join(', ');
         }
         if (!dartType.optionalParameterTypes.isEmpty) {
@@ -1862,7 +1867,9 @@ class _ReflectorDomain {
                   parameterType,
                   importCollector,
                   typeVariablesInScope,
-                  typedefs, logger, useNameOfGenericFunctionType: useNameOfGenericFunctionType));
+                  typedefs,
+                  logger,
+                  useNameOfGenericFunctionType: useNameOfGenericFunctionType));
           String connector = argumentTypes.length == 0 ? "" : ", ";
           argumentTypes = "$argumentTypes$connector"
               "[${optionalParameterTypeList.join(', ')}]";
@@ -1872,8 +1879,9 @@ class _ReflectorDomain {
           List<String> namedParameterTypeList =
               parameterMap.keys.map((String name) {
             DartType parameterType = parameterMap[name];
-            String typeCode = _typeCodeOfTypeArgument(
-                parameterType, importCollector, typeVariablesInScope, typedefs, logger, useNameOfGenericFunctionType: useNameOfGenericFunctionType);
+            String typeCode = _typeCodeOfTypeArgument(parameterType,
+                importCollector, typeVariablesInScope, typedefs, logger,
+                useNameOfGenericFunctionType: useNameOfGenericFunctionType);
             return "$typeCode $name";
           });
           String connector = argumentTypes.length == 0 ? "" : ", ";
@@ -1923,7 +1931,8 @@ class _ReflectorDomain {
       } else {
         if (dartType.typeArguments.every(_hasNoFreeTypeVariables)) {
           String typeArgumentCode = _typeCodeOfTypeArgument(
-              dartType, importCollector, typeVariablesInScope, typedefs, logger, useNameOfGenericFunctionType: true);
+              dartType, importCollector, typeVariablesInScope, typedefs, logger,
+              useNameOfGenericFunctionType: true);
           return "const m.TypeValue<$typeArgumentCode>().type";
         } else {
           String arguments = dartType.typeArguments
@@ -1949,8 +1958,8 @@ class _ReflectorDomain {
               dartType, importCollector, typeVariablesInScope, typedefs, logger,
               useNameOfGenericFunctionType: true);
         } else {
-          String typeArgumentCode = _typeCodeOfTypeArgument(
-              dartType, importCollector, typeVariablesInScope, typedefs, logger);
+          String typeArgumentCode = _typeCodeOfTypeArgument(dartType,
+              importCollector, typeVariablesInScope, typedefs, logger);
           return "const m.TypeValue<$typeArgumentCode>().type";
         }
       }
@@ -2288,8 +2297,8 @@ class _AnnotationClassFixedPoint extends FixedPoint<ClassElement> {
   final ElementToDomain elementToDomain;
   final TransformLogger logger;
 
-  _AnnotationClassFixedPoint(
-      this.resolver, this.generatedLibraryId, this.elementToDomain, this.logger);
+  _AnnotationClassFixedPoint(this.resolver, this.generatedLibraryId,
+      this.elementToDomain, this.logger);
 
   /// Returns the classes that occur as return types of covered methods or in
   /// type annotations of covered variables and parameters of covered methods,
@@ -2592,8 +2601,8 @@ class _ClassDomain {
               member.correspondingGetter;
           getterMetadata = correspondingGetter?.metadata;
         }
-        if (_reflectorDomain._capabilities
-            .supportsInstanceInvoke(member.name, metadata, getterMetadata, _logger)) {
+        if (_reflectorDomain._capabilities.supportsInstanceInvoke(
+            member.name, metadata, getterMetadata, _logger)) {
           result[name] = member;
         }
       }
@@ -2645,8 +2654,8 @@ class _ClassDomain {
     void possiblyAddMethod(MethodElement method) {
       if (method.isStatic &&
           !method.isPrivate &&
-          _reflectorDomain._capabilities
-          .supportsStaticInvoke(method.name, method.metadata, null, _logger)) {
+          _reflectorDomain._capabilities.supportsStaticInvoke(
+              method.name, method.metadata, null, _logger)) {
         result.add(method);
       }
     }
@@ -2665,8 +2674,8 @@ class _ClassDomain {
             accessor.correspondingGetter;
         getterMetadata = correspondingGetter?.metadata;
       }
-      if (_reflectorDomain._capabilities
-          .supportsStaticInvoke(accessor.name, metadata, getterMetadata, _logger)) {
+      if (_reflectorDomain._capabilities.supportsStaticInvoke(
+          accessor.name, metadata, getterMetadata, _logger)) {
         result.add(accessor);
       }
     }
@@ -2765,12 +2774,14 @@ class _Capabilities {
       String methodName,
       Iterable<ElementAnnotation> metadata,
       Iterable<ElementAnnotation> getterMetadata,
-                              TransformLogger logger) {
+      TransformLogger logger) {
     var v = _supportsInstanceInvoke(
         _capabilities,
         methodName,
         _getEvaluatedMetadata(metadata, logger),
-        getterMetadata == null ? null : _getEvaluatedMetadata(getterMetadata, logger));
+        getterMetadata == null
+            ? null
+            : _getEvaluatedMetadata(getterMetadata, logger));
     return v;
   }
 
@@ -2778,9 +2789,10 @@ class _Capabilities {
       String constructorName,
       Iterable<ElementAnnotation> metadata,
       LibraryElement libraryElement,
-      Resolver resolver, TransformLogger logger) {
-    var result = _supportsNewInstance(
-        _capabilities, constructorName, _getEvaluatedMetadata(metadata, logger));
+      Resolver resolver,
+      TransformLogger logger) {
+    var result = _supportsNewInstance(_capabilities, constructorName,
+        _getEvaluatedMetadata(metadata, logger));
     return result;
   }
 
@@ -2848,7 +2860,7 @@ class _Capabilities {
       String methodName,
       Iterable<ElementAnnotation> metadata,
       Iterable<ElementAnnotation> getterMetadata,
-                              TransformLogger logger) {
+      TransformLogger logger) {
     return _supportsTopLevelInvoke(
         _capabilities,
         methodName,
@@ -2869,7 +2881,8 @@ class _Capabilities {
         _getEvaluatedMetadata(metadata, logger),
         getterMetadata == null
             ? null
-            : _getEvaluatedMetadata(getterMetadata, logger), logger);
+            : _getEvaluatedMetadata(getterMetadata, logger),
+        logger);
   }
 
   bool get _supportsMetadata {
@@ -3465,7 +3478,8 @@ class TransformerImplementation {
             _capabilitiesOf(capabilityLibrary, reflector);
         assert(_isImportableLibrary(reflectorLibrary, dataId, _resolver));
         importCollector._addLibrary(reflectorLibrary);
-        return new _ReflectorDomain(_resolver, dataId, reflector, capabilities, _logger);
+        return new _ReflectorDomain(
+            _resolver, dataId, reflector, capabilities, _logger);
       });
     }
 
@@ -4500,14 +4514,17 @@ String _extractMetadataCode(Element element, Resolver resolver,
 /// Returns the top level variables declared in the given [libraryElement],
 /// filtering them such that the returned ones are those that are supported
 /// by [capabilities].
-Iterable<TopLevelVariableElement> _extractDeclaredVariables(Resolver resolver,
-                                                            LibraryElement libraryElement, _Capabilities capabilities, TransformLogger logger) sync* {
+Iterable<TopLevelVariableElement> _extractDeclaredVariables(
+    Resolver resolver,
+    LibraryElement libraryElement,
+    _Capabilities capabilities,
+    TransformLogger logger) sync* {
   for (CompilationUnitElement unit in libraryElement.units) {
     for (TopLevelVariableElement variable in unit.topLevelVariables) {
       if (variable.isPrivate || variable.isSynthetic) continue;
       // TODO(eernst) clarify: Do we want to subsume variables under invoke?
       if (capabilities.supportsTopLevelInvoke(
-              variable.name, variable.metadata, null, logger)) {
+          variable.name, variable.metadata, null, logger)) {
         yield variable;
       }
     }
@@ -4517,13 +4534,16 @@ Iterable<TopLevelVariableElement> _extractDeclaredVariables(Resolver resolver,
 /// Returns the top level functions declared in the given [libraryElement],
 /// filtering them such that the returned ones are those that are supported
 /// by [capabilities].
-Iterable<FunctionElement> _extractDeclaredFunctions(Resolver resolver,
-                                                    LibraryElement libraryElement, _Capabilities capabilities, TransformLogger logger) sync* {
+Iterable<FunctionElement> _extractDeclaredFunctions(
+    Resolver resolver,
+    LibraryElement libraryElement,
+    _Capabilities capabilities,
+    TransformLogger logger) sync* {
   for (CompilationUnitElement unit in libraryElement.units) {
     for (FunctionElement function in unit.functions) {
       if (function.isPrivate) continue;
       if (capabilities.supportsTopLevelInvoke(
-              function.name, function.metadata, null, logger)) {
+          function.name, function.metadata, null, logger)) {
         yield function;
       }
     }
@@ -4557,7 +4577,10 @@ typedef bool CapabilityChecker(
 /// Returns the declared fields in the given [classElement], filtered such
 /// that the returned ones are the ones that are supported by [capabilities].
 Iterable<FieldElement> _extractDeclaredFields(
-    Resolver resolver, ClassElement classElement, _Capabilities capabilities, TransformLogger logger) {
+    Resolver resolver,
+    ClassElement classElement,
+    _Capabilities capabilities,
+    TransformLogger logger) {
   return classElement.fields.where((FieldElement field) {
     if (field.isPrivate) return false;
     CapabilityChecker capabilityChecker = field.isStatic
@@ -4571,7 +4594,10 @@ Iterable<FieldElement> _extractDeclaredFields(
 /// Returns the declared methods in the given [classElement], filtered such
 /// that the returned ones are the ones that are supported by [capabilities].
 Iterable<MethodElement> _extractDeclaredMethods(
-    Resolver resolver, ClassElement classElement, _Capabilities capabilities, TransformLogger logger) {
+    Resolver resolver,
+    ClassElement classElement,
+    _Capabilities capabilities,
+    TransformLogger logger) {
   return classElement.methods.where((MethodElement method) {
     if (method.isPrivate) return false;
     CapabilityChecker capabilityChecker = method.isStatic
@@ -4605,8 +4631,11 @@ Iterable<ParameterElement> _extractDeclaredParameters(
 
 /// Returns the accessors from the given [libraryElement], filtered such that
 /// the returned ones are the ones that are supported by [capabilities].
-Iterable<ExecutableElement> _extractLibraryAccessors(Resolver resolver,
-                                                     LibraryElement libraryElement, _Capabilities capabilities, TransformLogger logger) sync* {
+Iterable<ExecutableElement> _extractLibraryAccessors(
+    Resolver resolver,
+    LibraryElement libraryElement,
+    _Capabilities capabilities,
+    TransformLogger logger) sync* {
   for (CompilationUnitElement unit in libraryElement.units) {
     for (PropertyAccessorElement accessor in unit.accessors) {
       if (accessor.isPrivate) continue;
@@ -4625,7 +4654,7 @@ Iterable<ExecutableElement> _extractLibraryAccessors(Resolver resolver,
         }
       }
       if (capabilities.supportsTopLevelInvoke(
-              accessor.name, metadata, getterMetadata, logger)) {
+          accessor.name, metadata, getterMetadata, logger)) {
         yield accessor;
       }
     }
@@ -4641,7 +4670,10 @@ Iterable<ExecutableElement> _extractLibraryAccessors(Resolver resolver,
 /// here, by filtering out the accessors whose `isSynthetic` is true
 /// and adding the fields.
 Iterable<PropertyAccessorElement> _extractAccessors(
-    Resolver resolver, ClassElement classElement, _Capabilities capabilities, TransformLogger logger) {
+    Resolver resolver,
+    ClassElement classElement,
+    _Capabilities capabilities,
+    TransformLogger logger) {
   return classElement.accessors.where((PropertyAccessorElement accessor) {
     if (accessor.isPrivate) return false;
     // TODO(eernst) implement: refactor treatment of `getterMetadata`
@@ -4671,24 +4703,28 @@ Iterable<ConstructorElement> _extractDeclaredConstructors(
     Resolver resolver,
     LibraryElement libraryElement,
     ClassElement classElement,
-    _Capabilities capabilities, TransformLogger logger) {
+    _Capabilities capabilities,
+    TransformLogger logger) {
   return classElement.constructors.where((ConstructorElement constructor) {
     if (constructor.isPrivate) return false;
-    return capabilities.supportsNewInstance(
-        constructor.name, constructor.metadata, libraryElement, resolver, logger);
+    return capabilities.supportsNewInstance(constructor.name,
+        constructor.metadata, libraryElement, resolver, logger);
   });
 }
 
 _LibraryDomain _createLibraryDomain(
     LibraryElement library, _ReflectorDomain domain, TransformLogger logger) {
   Iterable<TopLevelVariableElement> declaredVariablesOfLibrary =
-      _extractDeclaredVariables(domain._resolver, library, domain._capabilities, logger)
+      _extractDeclaredVariables(
+              domain._resolver, library, domain._capabilities, logger)
           .toList();
   Iterable<FunctionElement> declaredFunctionsOfLibrary =
-      _extractDeclaredFunctions(domain._resolver, library, domain._capabilities, logger)
+      _extractDeclaredFunctions(
+              domain._resolver, library, domain._capabilities, logger)
           .toList();
   Iterable<PropertyAccessorElement> accessorsOfLibrary =
-      _extractLibraryAccessors(domain._resolver, library, domain._capabilities, logger);
+      _extractLibraryAccessors(
+          domain._resolver, library, domain._capabilities, logger);
   Iterable<ParameterElement> declaredParametersOfLibrary =
       _extractDeclaredFunctionParameters(
           domain._resolver, declaredFunctionsOfLibrary, accessorsOfLibrary);
@@ -4701,18 +4737,20 @@ _LibraryDomain _createLibraryDomain(
       domain);
 }
 
-_ClassDomain _createClassDomain(ClassElement type, _ReflectorDomain domain, TransformLogger logger) {
+_ClassDomain _createClassDomain(
+    ClassElement type, _ReflectorDomain domain, TransformLogger logger) {
   if (type is MixinApplication) {
     Iterable<FieldElement> declaredFieldsOfClass = _extractDeclaredFields(
-        domain._resolver, type.mixin, domain._capabilities, logger)
+            domain._resolver, type.mixin, domain._capabilities, logger)
         .where((FieldElement e) => !e.isStatic)
         .toList();
     Iterable<MethodElement> declaredMethodsOfClass = _extractDeclaredMethods(
-        domain._resolver, type.mixin, domain._capabilities, logger)
+            domain._resolver, type.mixin, domain._capabilities, logger)
         .where((MethodElement e) => !e.isStatic)
         .toList();
     Iterable<PropertyAccessorElement> declaredAndImplicitAccessorsOfClass =
-        _extractAccessors(domain._resolver, type.mixin, domain._capabilities, logger)
+        _extractAccessors(
+                domain._resolver, type.mixin, domain._capabilities, logger)
             .toList();
     Iterable<ConstructorElement> declaredConstructorsOfClass =
         <ConstructorElement>[];
@@ -4730,17 +4768,18 @@ _ClassDomain _createClassDomain(ClassElement type, _ReflectorDomain domain, Tran
         domain);
   }
 
-  List<FieldElement> declaredFieldsOfClass =
-      _extractDeclaredFields(domain._resolver, type, domain._capabilities, logger)
-          .toList();
-  List<MethodElement> declaredMethodsOfClass =
-      _extractDeclaredMethods(domain._resolver, type, domain._capabilities, logger)
-          .toList();
+  List<FieldElement> declaredFieldsOfClass = _extractDeclaredFields(
+          domain._resolver, type, domain._capabilities, logger)
+      .toList();
+  List<MethodElement> declaredMethodsOfClass = _extractDeclaredMethods(
+          domain._resolver, type, domain._capabilities, logger)
+      .toList();
   List<PropertyAccessorElement> declaredAndImplicitAccessorsOfClass =
-      _extractAccessors(domain._resolver, type, domain._capabilities, logger).toList();
+      _extractAccessors(domain._resolver, type, domain._capabilities, logger)
+          .toList();
   List<ConstructorElement> declaredConstructorsOfClass =
-      _extractDeclaredConstructors(
-          domain._resolver, type.library, type, domain._capabilities, logger)
+      _extractDeclaredConstructors(domain._resolver, type.library, type,
+              domain._capabilities, logger)
           .toList();
   List<ParameterElement> declaredParametersOfClass = _extractDeclaredParameters(
       declaredMethodsOfClass,
@@ -5181,7 +5220,8 @@ EvaluationResultImpl _constTopLevelVariableEvaluationResult(
 /// [LibraryElement]. As an exception, when [elementAnnotation] denotes
 /// a getter or a constructor, `evaluationResult` is null; the value is
 /// then obtained indirectly.
-DartObject _getEvaluatedMetadatum(ElementAnnotation elementAnnotation, TransformLogger logger) {
+DartObject _getEvaluatedMetadatum(
+    ElementAnnotation elementAnnotation, TransformLogger logger) {
   DartObject fail() {
     logger.error("Metadata has a "
         "not yet supported form: $elementAnnotation.");
@@ -5227,5 +5267,6 @@ DartObject _getEvaluatedMetadatum(ElementAnnotation elementAnnotation, Transform
 /// in [metadata] using [_getEvaluatedMetadatum].
 Iterable<DartObject> _getEvaluatedMetadata(
     Iterable<ElementAnnotation> metadata, TransformLogger logger) {
-  return metadata.map((ElementAnnotation annotation) => _getEvaluatedMetadatum(annotation, logger));
+  return metadata.map((ElementAnnotation annotation) =>
+      _getEvaluatedMetadatum(annotation, logger));
 }

--- a/lib/src/transformer_implementation.dart
+++ b/lib/src/transformer_implementation.dart
@@ -129,11 +129,8 @@ class ReflectionWorld {
   Map<ClassElement, Set<ClassElement>> _subtypesCache;
 
   /// Returns code which will create all the data structures (esp. mirrors)
-  /// needed to enable the correct behavior for all [reflectors]. The
-  /// [resolver] is used to obtain static analysis information about the
-  /// entry point for this world, i.e., [entryPointLibrary], the [logger]
-  /// is used to report diagnostic messages, and [dataId] specifies the
-  /// asset where the generated code will be stored.
+  /// needed to enable the correct behavior for all [reflectors]. The [logger]
+  /// is used to report diagnostic messages.
   String generateCode(TransformLogger logger) {
     Iterable<String> reflectorsCode =
         reflectors.map((_ReflectorDomain reflector) {
@@ -3774,6 +3771,7 @@ initializeReflectable() {
       if (const bool.fromEnvironment("reflectable.pause.at.exit")) {
         _processedEntryPointCount++;
       }
+      _resolver.release();
       return;
     }
     reflectableLibrary = _resolvedLibraryOf(reflectableLibrary);
@@ -3790,6 +3788,7 @@ initializeReflectable() {
       if (const bool.fromEnvironment("reflectable.pause.at.exit")) {
         _processedEntryPointCount++;
       }
+      _resolver.release();
       return;
     }
 
@@ -3799,6 +3798,7 @@ initializeReflectable() {
       if (const bool.fromEnvironment("reflectable.pause.at.exit")) {
         _processedEntryPointCount++;
       }
+      _resolver.release();
       return;
     }
 

--- a/lib/src/transformer_implementation.dart
+++ b/lib/src/transformer_implementation.dart
@@ -141,10 +141,9 @@ class ReflectionWorld {
           reflector._generateCode(this, importCollector, logger, typedefs);
       if (!typedefs.isEmpty) {
         for (DartType dartType in typedefs.keys) {
-          String body =
-              reflector._typeCodeOfTypeArgument(
-                  dartType, importCollector, typeVariablesInScope, typedefs,
-                  useNameOfGenericFunctionType: false);
+          String body = reflector._typeCodeOfTypeArgument(
+              dartType, importCollector, typeVariablesInScope, typedefs,
+              useNameOfGenericFunctionType: false);
           typedefsCode +=
               "\ntypedef ${_typedefName(typedefs[dartType])} = $body;";
         }
@@ -1478,8 +1477,8 @@ class _ReflectorDomain {
                 .map(indexOf));
       }
 
-      int dynamicReflectedTypeIndex = _dynamicTypeCodeIndex(
-          classElement.type, classes, reflectedTypes, reflectedTypesOffset, typedefs);
+      int dynamicReflectedTypeIndex = _dynamicTypeCodeIndex(classElement.type,
+          classes, reflectedTypes, reflectedTypesOffset, typedefs);
 
       return 'new r.GenericClassMirrorImpl(r"${classDomain._simpleName}", '
           'r"${_qualifiedName(classElement)}", $descriptor, $classIndex, '
@@ -1515,12 +1514,12 @@ class _ReflectorDomain {
       assert(variableMirrorIndex != null);
       int reflectedTypeIndex = reflectedTypeRequested
           ? _typeCodeIndex(accessorElement.variable.type, classes,
-                           reflectedTypes, reflectedTypesOffset, typedefs)
+              reflectedTypes, reflectedTypesOffset, typedefs)
           : constants.NO_CAPABILITY_INDEX;
       // Do not check `reflectedTypeIndex != null`, null means dynamic.
       int dynamicReflectedTypeIndex = reflectedTypeRequested
           ? _dynamicTypeCodeIndex(accessorElement.variable.type, classes,
-                                  reflectedTypes, reflectedTypesOffset, typedefs)
+              reflectedTypes, reflectedTypesOffset, typedefs)
           : constants.NO_CAPABILITY_INDEX;
       // Do not check `dynamicReflectedTypeIndex != null`, null means dynamic.
       int selfIndex = members.indexOf(accessorElement) + fields.length;
@@ -1549,13 +1548,17 @@ class _ReflectorDomain {
       }));
       int reflectedReturnTypeIndex = constants.NO_CAPABILITY_INDEX;
       if (!element.returnType.isVoid && reflectedTypeRequested) {
-        reflectedReturnTypeIndex = _typeCodeIndex(
-            element.returnType, classes, reflectedTypes, reflectedTypesOffset, typedefs);
+        reflectedReturnTypeIndex = _typeCodeIndex(element.returnType, classes,
+            reflectedTypes, reflectedTypesOffset, typedefs);
       }
       int dynamicReflectedReturnTypeIndex = constants.NO_CAPABILITY_INDEX;
       if (!element.returnType.isVoid && reflectedTypeRequested) {
         dynamicReflectedReturnTypeIndex = _dynamicTypeCodeIndex(
-            element.returnType, classes, reflectedTypes, reflectedTypesOffset, typedefs);
+            element.returnType,
+            classes,
+            reflectedTypes,
+            reflectedTypesOffset,
+            typedefs);
       }
       String metadataCode = _capabilities._supportsMetadata
           ? _extractMetadataCode(
@@ -1581,12 +1584,12 @@ class _ReflectorDomain {
         _libraries.indexOf(element.enclosingElement.enclosingElement);
     int classMirrorIndex = _computeVariableTypeIndex(element, descriptor);
     int reflectedTypeIndex = reflectedTypeRequested
-        ? _typeCodeIndex(
-            element.type, classes, reflectedTypes, reflectedTypesOffset, typedefs)
+        ? _typeCodeIndex(element.type, classes, reflectedTypes,
+            reflectedTypesOffset, typedefs)
         : constants.NO_CAPABILITY_INDEX;
     int dynamicReflectedTypeIndex = reflectedTypeRequested
-        ? _dynamicTypeCodeIndex(
-            element.type, classes, reflectedTypes, reflectedTypesOffset, typedefs)
+        ? _dynamicTypeCodeIndex(element.type, classes, reflectedTypes,
+            reflectedTypesOffset, typedefs)
         : constants.NO_CAPABILITY_INDEX;
     String metadataCode;
     if (_capabilities._supportsMetadata) {
@@ -1615,12 +1618,12 @@ class _ReflectorDomain {
     int ownerIndex = classes.indexOf(element.enclosingElement);
     int classMirrorIndex = _computeVariableTypeIndex(element, descriptor);
     int reflectedTypeIndex = reflectedTypeRequested
-        ? _typeCodeIndex(
-            element.type, classes, reflectedTypes, reflectedTypesOffset, typedefs)
+        ? _typeCodeIndex(element.type, classes, reflectedTypes,
+            reflectedTypesOffset, typedefs)
         : constants.NO_CAPABILITY_INDEX;
     int dynamicReflectedTypeIndex = reflectedTypeRequested
-        ? _dynamicTypeCodeIndex(
-            element.type, classes, reflectedTypes, reflectedTypesOffset, typedefs)
+        ? _dynamicTypeCodeIndex(element.type, classes, reflectedTypes,
+            reflectedTypesOffset, typedefs)
         : constants.NO_CAPABILITY_INDEX;
     String metadataCode;
     if (_capabilities._supportsMetadata) {
@@ -1646,8 +1649,11 @@ class _ReflectorDomain {
   /// as computed by [reflectedTypes], because the elements in there will be
   /// added to `ReflectorData.types` after the elements of [classes] have been
   /// added.
-  int _typeCodeIndex(DartType dartType, ClassElementEnhancedSet classes,
-      Enumerator<ErasableDartType> reflectedTypes, int reflectedTypesOffset,
+  int _typeCodeIndex(
+      DartType dartType,
+      ClassElementEnhancedSet classes,
+      Enumerator<ErasableDartType> reflectedTypes,
+      int reflectedTypesOffset,
       Map<FunctionType, int> typedefs) {
     // The type `dynamic` is handled via the `dynamicAttribute` bit.
     if (dartType.isDynamic) return null;
@@ -1692,8 +1698,11 @@ class _ReflectorDomain {
   /// [reflectedTypesOffset] is used to adjust the index as computed by
   /// [reflectedTypes], because the elements in there will be added to
   /// `ReflectorData.types` after the elements of [classes] have been added.
-  int _dynamicTypeCodeIndex(DartType dartType, ClassElementEnhancedSet classes,
-      Enumerator<ErasableDartType> reflectedTypes, int reflectedTypesOffset,
+  int _dynamicTypeCodeIndex(
+      DartType dartType,
+      ClassElementEnhancedSet classes,
+      Enumerator<ErasableDartType> reflectedTypes,
+      int reflectedTypesOffset,
       Map<FunctionType, int> typedefs) {
     // The type `dynamic` is handled via the `dynamicAttribute` bit.
     if (dartType.isDynamic) return null;
@@ -1722,7 +1731,6 @@ class _ReflectorDomain {
         typedefs[dartType] = index;
       }
       return index;
-
     }
     // We only handle the kinds of types already covered above.
     return constants.NO_CAPABILITY_INDEX;
@@ -1764,7 +1772,8 @@ class _ReflectorDomain {
   /// name or a fully spelled-out generic function type (and it has no
   /// effect when [dartType] is not a generic function type).
   String _typeCodeOfTypeArgument(
-      DartType dartType, _ImportCollector importCollector,
+      DartType dartType,
+      _ImportCollector importCollector,
       Set<String> typeVariablesInScope,
       Map<FunctionType, int> typedefs,
       {bool useNameOfGenericFunctionType = true}) {
@@ -1789,7 +1798,10 @@ class _ReflectorDomain {
             (type) => _hasNoFreeTypeVariables(type, typeVariablesInScope))) {
           String arguments = dartType.typeArguments
               .map((DartType typeArgument) => _typeCodeOfTypeArgument(
-                  typeArgument, importCollector, typeVariablesInScope, typedefs))
+                  typeArgument,
+                  importCollector,
+                  typeVariablesInScope,
+                  typedefs))
               .join(', ');
           return "$prefix${classElement.name}<$arguments>";
         } else {
@@ -1820,8 +1832,8 @@ class _ReflectorDomain {
             }
           }
         }
-        String returnType = _typeCodeOfTypeArgument(
-            dartType.returnType, importCollector, typeVariablesInScope, typedefs);
+        String returnType = _typeCodeOfTypeArgument(dartType.returnType,
+            importCollector, typeVariablesInScope, typedefs);
         String typeArguments = "";
         if (!dartType.typeFormals.isEmpty) {
           List<String> typeArgumentList = dartType.typeFormals.map(
@@ -1832,14 +1844,20 @@ class _ReflectorDomain {
         if (!dartType.normalParameterTypes.isEmpty) {
           List<String> normalParameterTypeList = dartType.normalParameterTypes
               .map((DartType parameterType) => _typeCodeOfTypeArgument(
-                  parameterType, importCollector, typeVariablesInScope, typedefs));
+                  parameterType,
+                  importCollector,
+                  typeVariablesInScope,
+                  typedefs));
           argumentTypes = normalParameterTypeList.join(', ');
         }
         if (!dartType.optionalParameterTypes.isEmpty) {
           List<String> optionalParameterTypeList = dartType
               .optionalParameterTypes
               .map((DartType parameterType) => _typeCodeOfTypeArgument(
-                  parameterType, importCollector, typeVariablesInScope, typedefs));
+                  parameterType,
+                  importCollector,
+                  typeVariablesInScope,
+                  typedefs));
           String connector = argumentTypes.length == 0 ? "" : ", ";
           argumentTypes = "$argumentTypes$connector"
               "[${optionalParameterTypeList.join(', ')}]";
@@ -1899,8 +1917,8 @@ class _ReflectorDomain {
         return "$prefix${classElement.name}";
       } else {
         if (dartType.typeArguments.every(_hasNoFreeTypeVariables)) {
-          String typeArgumentCode =
-              _typeCodeOfTypeArgument(dartType, importCollector, typeVariablesInScope, typedefs);
+          String typeArgumentCode = _typeCodeOfTypeArgument(
+              dartType, importCollector, typeVariablesInScope, typedefs);
           return "const m.TypeValue<$typeArgumentCode>().type";
         } else {
           String arguments = dartType.typeArguments
@@ -1922,10 +1940,12 @@ class _ReflectorDomain {
         if (!dartType.typeFormals.isEmpty) {
           // `dartType` is a generic function type, so we must use a
           // separately generated `typedef` to obtain a `Type` for it.
-          return _typeCodeOfTypeArgument(dartType, importCollector, typeVariablesInScope, typedefs, useNameOfGenericFunctionType: true);
+          return _typeCodeOfTypeArgument(
+              dartType, importCollector, typeVariablesInScope, typedefs,
+              useNameOfGenericFunctionType: true);
         } else {
-          String typeArgumentCode =
-              _typeCodeOfTypeArgument(dartType, importCollector, typeVariablesInScope, typedefs);
+          String typeArgumentCode = _typeCodeOfTypeArgument(
+              dartType, importCollector, typeVariablesInScope, typedefs);
           return "const m.TypeValue<$typeArgumentCode>().type";
         }
       }
@@ -2079,12 +2099,12 @@ class _ReflectorDomain {
       classMirrorIndex = constants.NO_CAPABILITY_INDEX;
     }
     int reflectedTypeIndex = reflectedTypeRequested
-        ? _typeCodeIndex(
-            element.type, classes, reflectedTypes, reflectedTypesOffset, typedefs)
+        ? _typeCodeIndex(element.type, classes, reflectedTypes,
+            reflectedTypesOffset, typedefs)
         : constants.NO_CAPABILITY_INDEX;
     int dynamicReflectedTypeIndex = reflectedTypeRequested
-        ? _dynamicTypeCodeIndex(
-            element.type, classes, reflectedTypes, reflectedTypesOffset, typedefs)
+        ? _dynamicTypeCodeIndex(element.type, classes, reflectedTypes,
+            reflectedTypesOffset, typedefs)
         : constants.NO_CAPABILITY_INDEX;
     String metadataCode = "null";
     if (_capabilities._supportsMetadata) {

--- a/lib/src/transformer_implementation.dart
+++ b/lib/src/transformer_implementation.dart
@@ -1237,12 +1237,10 @@ class _ReflectorDomain {
     });
 
     String declarationsCode = _capabilities._impliesDeclarations
-        ? _formatAsConstList(
-            "int",
-            () sync* {
-              yield* fieldsIndices;
-              yield* methodsIndices;
-            }())
+        ? _formatAsConstList("int", () sync* {
+            yield* fieldsIndices;
+            yield* methodsIndices;
+          }())
         : "const <int>[${constants.NO_CAPABILITY_INDEX}]";
 
     // All instance members belong to the behavioral interface, so they
@@ -1695,13 +1693,13 @@ class _ReflectorDomain {
       [Set<String> typeVariablesInScope]) {
     if (type is TypeParameterType &&
         (typeVariablesInScope == null ||
-         !typeVariablesInScope.contains(type.name))) {
+            !typeVariablesInScope.contains(type.name))) {
       return false;
     }
     if (type is InterfaceType) {
       if (type.typeArguments.isEmpty) return true;
-      return type.typeArguments.every(
-          (type) => _hasNoFreeTypeVariables(type, typeVariablesInScope));
+      return type.typeArguments
+          .every((type) => _hasNoFreeTypeVariables(type, typeVariablesInScope));
     }
     // Possible kinds of types at this point (apart from several types
     // indicating an error that we do not expect here): `BottomTypeImpl`,
@@ -1736,10 +1734,10 @@ class _ReflectorDomain {
         return "$prefix${classElement.name}";
       } else {
         if (dartType.typeArguments.every(
-                (type) => _hasNoFreeTypeVariables(type, typeVariablesInScope))) {
+            (type) => _hasNoFreeTypeVariables(type, typeVariablesInScope))) {
           String arguments = dartType.typeArguments
-              .map((DartType typeArgument) =>
-                   _typeCodeOfTypeArgument(typeArgument, importCollector, typeVariablesInScope))
+              .map((DartType typeArgument) => _typeCodeOfTypeArgument(
+                  typeArgument, importCollector, typeVariablesInScope))
               .join(', ');
           return "$prefix${classElement.name}<$arguments>";
         } else {
@@ -1755,44 +1753,44 @@ class _ReflectorDomain {
         if (!dartType.typeFormals.isEmpty) {
           if (typeVariablesInScope == null) {
             typeVariablesInScope = new Set<String>();
-            for (TypeParameterElement element in dartType.typeFormals) {
-              typeVariablesInScope.add(element.name);
-            }
+          }
+          for (TypeParameterElement element in dartType.typeFormals) {
+            typeVariablesInScope.add(element.name);
           }
         }
-        String returnType =
-            _typeCodeOfTypeArgument(dartType.returnType, importCollector, typeVariablesInScope);
+        String returnType = _typeCodeOfTypeArgument(
+            dartType.returnType, importCollector, typeVariablesInScope);
         String typeArguments = "";
         if (!dartType.typeFormals.isEmpty) {
-          List<String> typeArgumentList = dartType.typeArguments
-              .map((DartType typeArgument) =>
-                   _typeCodeOfTypeArgument(typeArgument, importCollector, typeVariablesInScope));
+          List<String> typeArgumentList = dartType.typeFormals.map(
+              (TypeParameterElement typeParameter) => typeParameter.toString());
           typeArguments = "<${typeArgumentList.join(', ')}>";
         }
         String argumentTypes = "";
         if (!dartType.normalParameterTypes.isEmpty) {
           List<String> normalParameterTypeList = dartType.normalParameterTypes
-              .map((DartType parameterType) =>
-                   _typeCodeOfTypeArgument(parameterType, importCollector, typeVariablesInScope));
+              .map((DartType parameterType) => _typeCodeOfTypeArgument(
+                  parameterType, importCollector, typeVariablesInScope));
           argumentTypes = normalParameterTypeList.join(', ');
         }
         if (!dartType.optionalParameterTypes.isEmpty) {
           List<String> optionalParameterTypeList = dartType
-              .optionalParameterTypes.map((DartType parameterType) =>
-                                          _typeCodeOfTypeArgument(parameterType, importCollector, typeVariablesInScope));
+              .optionalParameterTypes
+              .map((DartType parameterType) => _typeCodeOfTypeArgument(
+                  parameterType, importCollector, typeVariablesInScope));
           String connector = argumentTypes.length == 0 ? "" : ", ";
           argumentTypes = "$argumentTypes$connector"
               "[${optionalParameterTypeList.join(', ')}]";
         }
         if (!dartType.namedParameterTypes.isEmpty) {
           Map<String, DartType> parameterMap = dartType.namedParameterTypes;
-          List<String> namedParameterTypeList = parameterMap.keys
-              .map((String name) {
-                  DartType parameterType = parameterMap[name];
-                  String typeCode =
-                      _typeCodeOfTypeArgument(parameterType, importCollector, typeVariablesInScope);
-                  return "$name: $typeCode";
-                });
+          List<String> namedParameterTypeList =
+              parameterMap.keys.map((String name) {
+            DartType parameterType = parameterMap[name];
+            String typeCode = _typeCodeOfTypeArgument(
+                parameterType, importCollector, typeVariablesInScope);
+            return "$typeCode $name";
+          });
           String connector = argumentTypes.length == 0 ? "" : ", ";
           argumentTypes = "$argumentTypes$connector"
               "{${namedParameterTypeList.join(', ')}}";
@@ -1800,8 +1798,8 @@ class _ReflectorDomain {
         return "$returnType Function$typeArguments($argumentTypes)";
       }
     } else if (dartType is TypeParameterType &&
-               typeVariablesInScope != null &&
-               typeVariablesInScope.contains(dartType.name)) {
+        typeVariablesInScope != null &&
+        typeVariablesInScope.contains(dartType.name)) {
       return dartType.name;
     } else {
       throw fail();
@@ -2135,8 +2133,10 @@ class _SuperclassFixedPoint extends FixedPoint<ClassElement> {
         if (classElement.supertype == null) return false;
         return helper(classElement.supertype.element, false);
       }
+
       return upwardsClosureBounds.keys.any(isSuperclassOfClassElement);
     }
+
     return upwardsClosureBounds.isEmpty || helper(classElement, true);
   }
 }
@@ -2473,8 +2473,10 @@ class _ClassDomain {
         if (member.isPrivate) return;
         // If [member] is a synthetic accessor created from a field, search for
         // the metadata on the original field.
-        List<ElementAnnotation> metadata = (member is PropertyAccessorElement &&
-            member.isSynthetic) ? member.variable.metadata : member.metadata;
+        List<ElementAnnotation> metadata =
+            (member is PropertyAccessorElement && member.isSynthetic)
+                ? member.variable.metadata
+                : member.metadata;
         List<ElementAnnotation> getterMetadata = null;
         if (_reflectorDomain._capabilities._impliesCorrespondingSetters &&
             member is PropertyAccessorElement &&
@@ -3165,7 +3167,8 @@ class TransformerImplementation {
           if (metadatum.element == globalQuantifyCapabilityConstructor) {
             DartObject value = _getEvaluatedMetadatum(metadatum);
             if (value != null) {
-              String pattern = value.getField("classNamePattern").toStringValue();
+              String pattern =
+                  value.getField("classNamePattern").toStringValue();
               if (pattern == null) {
                 // TODO(sigurdm) implement: Create a span for the annotation
                 // rather than the import.
@@ -3570,14 +3573,20 @@ class TransformerImplementation {
     String extractNamePattern(DartObject constant) {
       if (constant.getField("(super)") == null ||
           constant.getField("(super)").getField("namePattern") == null ||
-          constant.getField("(super)").getField("namePattern").toStringValue() ==
+          constant
+                  .getField("(super)")
+                  .getField("namePattern")
+                  .toStringValue() ==
               null) {
         // TODO(eernst) implement: Add location info to message.
         _warn(WarningKind.badNamePattern,
             "Could not extract namePattern from capability.");
         return "";
       }
-      return constant.getField("(super)").getField("namePattern").toStringValue();
+      return constant
+          .getField("(super)")
+          .getField("namePattern")
+          .toStringValue();
     }
 
     /// Extracts the metadata property from an instance of a subclass of
@@ -3591,7 +3600,8 @@ class TransformerImplementation {
         return null;
       }
       Object metadataFieldValue = constant
-          .getField("(super)").getField("metadataType")
+          .getField("(super)")
+          .getField("metadataType")
           .toTypeValue()
           .element;
       if (metadataFieldValue is! ClassElement) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: reflectable
-version: 2.0.0-dev.2.0
+version: 2.0.0-dev.3.0
 description: >
   This package allows programmers to reduce certain usages of dynamic
   reflection to a statically specified subset thereof, based on generated

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,8 +25,8 @@ dependencies:
   path: '>=1.2.0 <1.6.0'
   source_span: '>=1.0.0 <1.5.0'
 dev_dependencies:
-  test: ^0.12.0
   build_test: ^0.10.0
+  test: ^0.12.0
 transformers:
 - $dart2js:
     commandLineOptions: [--show-package-warnings]

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   build: ^0.12.0
   build_barback: ^0.5.0
   build_config: ^0.2.0
-  build_runner: ^0.7.0
+  build_runner: ^0.8.0
   code_transformers: '>=0.4.1 <0.6.0'
   dart_style: '>=0.2.0 <2.0.0'
   glob: ^1.1.0
@@ -26,6 +26,7 @@ dependencies:
   source_span: '>=1.0.0 <1.5.0'
 dev_dependencies:
   test: ^0.12.0
+  build_test: ^0.10.0
 transformers:
 - $dart2js:
     commandLineOptions: [--show-package-warnings]

--- a/test/arguments_test.dart
+++ b/test/arguments_test.dart
@@ -7,7 +7,6 @@ library reflectable.test.mock_tests.arguments_test;
 /// Check that attempts to have a non-empty argument list in a reflector
 /// constructor is detected and diagnosed as an error.
 
-import 'dart:io';
 import 'package:barback/barback.dart';
 import "package:reflectable/test_transform.dart";
 import "package:reflectable/transformer.dart";

--- a/test/check_literal_transform_test.dart
+++ b/test/check_literal_transform_test.dart
@@ -6,7 +6,6 @@ library reflectable.test.mock_tests.check_literal_transform_test;
 
 /// Test the literal output of the transformation for a few simple cases.
 
-import 'dart:io';
 import 'package:barback/barback.dart';
 import "package:reflectable/test_transform.dart";
 import "package:reflectable/transformer.dart";

--- a/test/constructor_const_test.dart
+++ b/test/constructor_const_test.dart
@@ -6,7 +6,6 @@ library reflectable.test.mock_tests.constructor_const_test;
 
 /// Checks that a non-const reflector constructor is an error.
 
-import 'dart:io';
 import 'package:barback/barback.dart';
 import "package:reflectable/test_transform.dart";
 import "package:reflectable/transformer.dart";

--- a/test/generate_private_test.dart
+++ b/test/generate_private_test.dart
@@ -7,7 +7,6 @@ library reflectable.test.mock_tests.generate_private_test;
 /// Check that attempts to generate expressions that contain private names
 /// from different libraries are detected and diagnosed as an error.
 
-import 'dart:io';
 import 'package:barback/barback.dart';
 import "package:reflectable/test_transform.dart";
 import "package:reflectable/transformer.dart";

--- a/tool/Makefile
+++ b/tool/Makefile
@@ -10,7 +10,7 @@ OPTIONS=--checked --package-root=$(PACKAGE_ROOT)
 TEST_DIR=../test
 XFORM_DIR=../test/to_be_transformed
 
-all: get clean build check test
+all: get check pub_test
 
 g: get
 
@@ -18,11 +18,9 @@ u: upgrade
 
 c: check
 
-b: build
-
 t: test
 
-cb: clean build
+pt: pub_test
 
 get:
 	( cd ..; pub get )
@@ -31,7 +29,7 @@ upgrade:
 	( cd ..; pub upgrade )
 
 check:
-	( cd ..; dartanalyzer `find lib test -name \*.dart` )
+	( cd ..; dartanalyzer --preview-dart-2 `find lib test -name \*.dart` )
 
 build:
 	@echo "[No actions for build in reflectable]"
@@ -39,6 +37,9 @@ build:
 test:
 	@echo "-------------------- mock_tests"
 	@./run_tests
+
+pub_test:
+	( cd ..; pub run test )
 
 clean:
 	@echo "[No actions for clean in reflectable]"

--- a/tool/Makefile
+++ b/tool/Makefile
@@ -25,20 +25,20 @@ t: test
 cb: clean build
 
 get:
-	( cd ..; pub get --no-packages-dir )
+	( cd ..; pub get )
 
 upgrade:
-	( cd ..; pub upgrade --no-packages-dir )
+	( cd ..; pub upgrade )
 
 check:
-	( cd ..; dartanalyzer `find lib bin test -name \*.dart` )
+	( cd ..; dartanalyzer `find lib test -name \*.dart` )
 
 build:
-	( cd ..; pub build --mode=debug test )
+	@echo "[No actions for build in reflectable]"
 
 test:
 	@echo "-------------------- mock_tests"
-	@./run_mock_tests
+	@./run_tests
 
 clean:
 	@echo "[No actions for clean in reflectable]"

--- a/tool/run_tests
+++ b/tool/run_tests
@@ -4,10 +4,9 @@
 # source code is governed by a BSD-style license that can be found in
 # the LICENSE file.
 
-TEST_DIR=../build/test
-PACKAGE_ROOT=../build/test/packages
+TEST_DIR=../test
 
-for n in $TEST_DIR/*.dart; do
+for n in $TEST_DIR/*_test.dart; do
   echo "---------- $(basename $n)"
-  dart --package-root=$PACKAGE_ROOT $n
+  dart $n
 done


### PR DESCRIPTION
One rather voluminous change in this PR is about function types: Until now, reflectable was not aware of inline function types (like an inline `int Function()`, as opposed to the ones which were defined indirectly defined via a `typedef`). This PR introduces support for the new function type syntax.

There is one outstanding issue: We cannot recognize generic function types, because they must be defined in terms of a `typedef`, and the corresponding `Type` objects are _not_ equal even though two given `typedef`s define the same generic function type. However, it is still possible to use generic function types if they are defined via a `typedef` and the client is careful to always use the same `typedef` for the same function type. This will be fixed, but this is a change to `Type` and not a change to reflectable.

A number of other changes are associated with the "administration" of the package, e.g., `.gitignore` was updated to match the new paths used by Dart tools for generated files, CHANGELOG.md and README.md were updated, and so was pubspec.yaml. Changes to `build.yaml` were necessary in order to get the desired behavior of the build package (which handles code generation and accepts the reflectable code generator as a kind of plugin).