### PR TITLE
Bumping version to 2.0.3

### DIFF
--- a/lib/src/builder_implementation.dart
+++ b/lib/src/builder_implementation.dart
@@ -3917,7 +3917,6 @@ initializeReflectable() {
     for (LibraryElement library in _libraries) {
       if (library.name != null) _librariesByName[library.name] = library;
     }
-    print(_librariesByName); // DEBUG
     LibraryElement reflectableLibrary =
         _librariesByName["reflectable.reflectable"];
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,8 @@
 name: reflectable
 version: 2.0.3
 description: >
-  This package allows programmers to reduce certain usages of dynamic
-  reflection to a statically specified subset thereof, based on generated
-  code with the same behavior as mirrors provided by 'dart:mirrors'. The
-  generated code does not use dynamic reflection and thus improves the
-  resource economy (esp. by using a smaller amount of space than dart2js
-  generated code).
+  Reflection support based on code generation, using 'capabilities' to
+  specify which operations to support, on which objects.
 author: The Dart Team <dart@google.com>
 homepage: https://www.github.com/dart-lang/reflectable
 environment:
@@ -27,8 +23,3 @@ dependencies:
 dev_dependencies:
   build_test: ^0.10.0
   test: ^1.2.0
-transformers:
-- $dart2js:
-    commandLineOptions: [--show-package-warnings]
-    # We do not want to compile anything in this package.
-    $include: []


### PR DESCRIPTION
For publishing on pub.dartlang.org as 2.0.3, just changing the pubspec.yaml description to fit in the recommended max size (180 chars), and removing the 'transformers:' section which is now unused.