### PR TITLE
Fix #132

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.7
+
+* Bug fix #132: 
+
 ## 2.0.6
 
 * Adjusts an implementation class (`MixinApplication`) such that a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## 2.0.7
 
-* Bug fix #132: 
+* Bug fix #132: We used to generate terms like `prefix2.di.inject` in order 
+  to denote a top level declaration named `inject`, but that's an error 
+  because `di` is an import prefix from client code. We now strip off such
+  prefixes (yielding `prefix2.inject`) in the cases reported in issue #132.
 
 ## 2.0.6
 

--- a/lib/src/builder_implementation.dart
+++ b/lib/src/builder_implementation.dart
@@ -4531,7 +4531,7 @@ String _extractMetadataCode(Element element, Resolver resolver,
 String _extractNameWithoutPrefix(Identifier identifier, Element errorTarget) {
   String name;
   if (identifier is SimpleIdentifier) {
-    name = identifier.token.stringValue;
+    name = identifier.token.lexeme;
   } else if (identifier is PrefixedIdentifier) {
     // The identifier is of the form `p.id` where `p` is a library
     // prefix, or it is on the form `C.id` where `C` is a class and
@@ -4540,14 +4540,15 @@ String _extractNameWithoutPrefix(Identifier identifier, Element errorTarget) {
       // We will replace the library prefix by the appropriate prefix for
       // code in the generated library, so we omit the prefix specified in
       // client code.
-      name = "${identifier.identifier.token.stringValue}";
+      name = identifier.identifier.token.lexeme;
     } else {
       // We must preserve the prefix which is a class name.
-      name = "${identifier.name}";
+      name = identifier.name;
     }
   } else {
     _severe("This kind of identifier is not yet supported: $identifier",
         errorTarget);
+    name = identifier.name;
   }
   return name;
 }

--- a/lib/src/builder_implementation.dart
+++ b/lib/src/builder_implementation.dart
@@ -4534,7 +4534,32 @@ String _extractMetadataCode(Element element, Resolver resolver,
       if (_isPrivateName(annotationNode.name.name)) {
         _severe("Cannot access private name ${annotationNode.name}", element);
       }
-      metadataParts.add("$prefix${annotationNode.name}");
+      Identifier annotationName = annotationNode.name;
+      String name;
+      if (annotationName is SimpleIdentifier) {
+        name = "$annotationName";
+      } else if (annotationName is PrefixedIdentifier) {
+        // The annotation is on the form `@p.id` where `p` is a library
+        // prefix, or it is on the form `@C.id` where `C` is a class and
+        // `id` a constant class variable.
+        if (annotationName.prefix.staticElement is PrefixElement) {
+          // We must replace the library prefix by the appropriate prefix for
+          // code in the generated library, so we omit `prefix`.
+          name = "${annotationName.identifier}";
+        } else {
+          // We must preserve the prefix which is a class name.
+          name = "$annotationName";
+        }
+        // In both cases we must include the library prefix.
+        prefix = importCollector._getPrefix(annotationNode.element.library);
+      } else {
+        _severe("This kind of metadata not yet supported: $annotationNode",
+            element);
+      }
+      if (_isPrivateName(name)) {
+        _severe("Cannot access private name $name", element);
+      }
+      metadataParts.add("$prefix$name");
     }
   }
 

--- a/lib/src/builder_implementation.dart
+++ b/lib/src/builder_implementation.dart
@@ -4498,28 +4498,7 @@ String _extractMetadataCode(Element element, Resolver resolver,
     String prefix = importCollector._getPrefix(annotationLibrary);
     if (annotationNode.arguments != null) {
       // A const constructor.
-      Identifier annotationName = annotationNode.name;
-      String name;
-      if (annotationName is SimpleIdentifier) {
-        name = "$annotationName";
-      } else if (annotationName is PrefixedIdentifier) {
-        // The annotation is on the form `@p.C(..)` where `p` is a library
-        // prefix, or it is on the form `@C.n(..)` where `C` is a class and
-        // `n` a named constructor.
-        if (annotationName.prefix.staticElement is PrefixElement) {
-          // We must replace the library prefix by the appropriate prefix for
-          // code in the generated library, so we omit `prefix`.
-          name = "${annotationName.identifier}";
-        } else {
-          // We must preserve the prefix which is a class name.
-          name = "$annotationName";
-        }
-        // In both cases we must include the library prefix.
-        prefix = importCollector._getPrefix(annotationNode.element.library);
-      } else {
-        _severe("This kind of metadata not yet supported: $annotationNode",
-            element);
-      }
+      String name = _extractNameWithoutPrefix(annotationNode.name, element);
       String arguments =
           annotationNode.arguments.arguments.map((Expression argument) {
         return _extractConstantCode(
@@ -4534,28 +4513,7 @@ String _extractMetadataCode(Element element, Resolver resolver,
       if (_isPrivateName(annotationNode.name.name)) {
         _severe("Cannot access private name ${annotationNode.name}", element);
       }
-      Identifier annotationName = annotationNode.name;
-      String name;
-      if (annotationName is SimpleIdentifier) {
-        name = "$annotationName";
-      } else if (annotationName is PrefixedIdentifier) {
-        // The annotation is on the form `@p.id` where `p` is a library
-        // prefix, or it is on the form `@C.id` where `C` is a class and
-        // `id` a constant class variable.
-        if (annotationName.prefix.staticElement is PrefixElement) {
-          // We must replace the library prefix by the appropriate prefix for
-          // code in the generated library, so we omit `prefix`.
-          name = "${annotationName.identifier}";
-        } else {
-          // We must preserve the prefix which is a class name.
-          name = "$annotationName";
-        }
-        // In both cases we must include the library prefix.
-        prefix = importCollector._getPrefix(annotationNode.element.library);
-      } else {
-        _severe("This kind of metadata not yet supported: $annotationNode",
-            element);
-      }
+      String name = _extractNameWithoutPrefix(annotationNode.name, element);
       if (_isPrivateName(name)) {
         _severe("Cannot access private name $name", element);
       }
@@ -4564,6 +4522,32 @@ String _extractMetadataCode(Element element, Resolver resolver,
   }
 
   return _formatAsConstList("Object", metadataParts);
+}
+
+/// Extract the plain name from by [identifier] by stripping off the
+/// library import prefix at front, if any.
+String _extractNameWithoutPrefix(Identifier identifier, Element errorTarget) {
+  String name;
+  if (identifier is SimpleIdentifier) {
+    name = "$identifier";
+  } else if (identifier is PrefixedIdentifier) {
+    // The identifier is of the form `p.id` where `p` is a library
+    // prefix, or it is on the form `C.id` where `C` is a class and
+    // `id` a named constructor.
+    if (identifier.prefix.staticElement is PrefixElement) {
+      // We will replace the library prefix by the appropriate prefix for
+      // code in the generated library, so we omit the prefix specified in
+      // client code.
+      name = "${identifier.identifier}";
+    } else {
+      // We must preserve the prefix which is a class name.
+      name = "$identifier";
+    }
+  } else {
+    _severe("This kind of identifier is not yet supported: $identifier",
+        errorTarget);
+  }
+  return name;
 }
 
 /// Returns the top level variables declared in the given [libraryElement],

--- a/lib/src/builder_implementation.dart
+++ b/lib/src/builder_implementation.dart
@@ -3304,10 +3304,12 @@ class BuilderImplementation {
     return null;
   }
 
-  void _warn(WarningKind kind, String message, [Element element]) {
+  /// Adds a warning to the log, using the source code location of `target`
+  /// to identify the relevant location where the error occurs.
+  void _warn(WarningKind kind, String message, [Element target]) {
     if (_warningEnabled(kind)) {
-      if (element != null) {
-        log.warning(_formatDiagnosticMessage(message, element));
+      if (target != null) {
+        log.warning(_formatDiagnosticMessage(message, target));
       } else {
         log.warning(message);
       }
@@ -4524,12 +4526,12 @@ String _extractMetadataCode(Element element, Resolver resolver,
   return _formatAsConstList("Object", metadataParts);
 }
 
-/// Extract the plain name from by [identifier] by stripping off the
+/// Extract the plain name from [identifier] by stripping off the
 /// library import prefix at front, if any.
 String _extractNameWithoutPrefix(Identifier identifier, Element errorTarget) {
   String name;
   if (identifier is SimpleIdentifier) {
-    name = "$identifier";
+    name = identifier.token.stringValue;
   } else if (identifier is PrefixedIdentifier) {
     // The identifier is of the form `p.id` where `p` is a library
     // prefix, or it is on the form `C.id` where `C` is a class and
@@ -4538,10 +4540,10 @@ String _extractNameWithoutPrefix(Identifier identifier, Element errorTarget) {
       // We will replace the library prefix by the appropriate prefix for
       // code in the generated library, so we omit the prefix specified in
       // client code.
-      name = "${identifier.identifier}";
+      name = "${identifier.identifier.token.stringValue}";
     } else {
       // We must preserve the prefix which is a class name.
-      name = "$identifier";
+      name = "${identifier.name}";
     }
   } else {
     _severe("This kind of identifier is not yet supported: $identifier",
@@ -5105,29 +5107,35 @@ Iterable<DartObject> _getEvaluatedMetadata(
       (ElementAnnotation annotation) => _getEvaluatedMetadatum(annotation));
 }
 
-void _severe(String message, [Element element]) {
-  if (element != null) {
-    log.severe(_formatDiagnosticMessage(message, element));
+/// Adds a severe error to the log, using the source code location of `target`
+/// to identify the relevant location where the error occurs.
+void _severe(String message, [Element target]) {
+  if (target != null) {
+    log.severe(_formatDiagnosticMessage(message, target));
   } else {
     log.severe(message);
   }
 }
 
-void _fine(String message, [Element element]) {
-  if (element != null) {
-    log.fine(_formatDiagnosticMessage(message, element));
+/// Adds a 'fine' message to the log, using the source code location of `target`
+/// to identify the relevant location where the issue occurs.
+void _fine(String message, [Element target]) {
+  if (target != null) {
+    log.fine(_formatDiagnosticMessage(message, target));
   } else {
     log.fine(message);
   }
 }
 
-String _formatDiagnosticMessage(String message, Element element) {
-  Source source = element?.source;
+/// Returns a string containing the given [message] and identifying the
+/// associated source code location as the location of the given [target].
+String _formatDiagnosticMessage(String message, Element target) {
+  Source source = target?.source;
   if (source == null) return message;
   String locationString = "";
-  int nameOffset = element.nameOffset;
+  int nameOffset = target.nameOffset;
   if (nameOffset != null) {
-    var location = element.unit?.lineInfo?.getLocation(nameOffset);
+    var location = target.unit?.lineInfo?.getLocation(nameOffset);
     if (location != null) {
       locationString = "${location.lineNumber}:${location.columnNumber}";
     }
@@ -5136,10 +5144,11 @@ String _formatDiagnosticMessage(String message, Element element) {
 }
 
 // Emits a warning-level log message which will be preserved by `pub run`
-// (as opposed to stdout and stderr which are swallowed).
+// (as opposed to stdout and stderr which are swallowed). If given, [target]
+// is used to indicate a source code location.
 // ignore:unused_element
-void _emitMessage(String message, [Element element]) {
+void _emitMessage(String message, [Element target]) {
   var formattedMessage =
-      element != null ? _formatDiagnosticMessage(message, element) : message;
+      target != null ? _formatDiagnosticMessage(message, target) : message;
   log.warning(formattedMessage);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: reflectable
-version: 2.0.6
+version: 2.0.7
 description: >
   Reflection support based on code generation, using 'capabilities' to
   specify which operations to support, on which objects.


### PR DESCRIPTION
Reflectable code generation is now stripping client import prefix when generating metadata code for a const variable. For instance, before this PR we generated `prefix2.di.inject`, where `di.inject` is the term used in a client library to access the top level declaration `inject` and `di` is an import prefix, and now we generate something like `prefix2.inject`.