### PR TITLE
Port reflectable to build 1.0.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## 2.0.8
 
 * Fix version conflict #153: Updated version constraints on analyzer, build,
-  build_runner, and test.
+  build_runner, and test. Ported reflectable_builder.dart to work with new
+  build API.
 
 ## 2.0.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.0.8
+
+* Fix version conflict #153: Updated version constraints on analyzer, build,
+  build_runner, and test.
+
 ## 2.0.7
 
 * Bug fix #132: We used to generate terms like `prefix2.di.inject` in order 

--- a/lib/reflectable_builder.dart
+++ b/lib/reflectable_builder.dart
@@ -9,74 +9,7 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
 import 'package:build_config/build_config.dart';
 import 'package:build_runner_core/build_runner_core.dart';
-import 'package:build_runner/src/logging/std_io_logging.dart';
-import 'package:build_runner/src/package_graph/build_config_overrides.dart';
-import 'package:build_runner/src/generate/terminator.dart';
 import 'src/builder_implementation.dart';
-
-Future<BuildResult> _build(List<BuilderApplication> builders,
-    {bool deleteFilesByDefault,
-    bool assumeTty,
-    String configKey,
-    PackageGraph packageGraph,
-    RunnerAssetReader reader,
-    RunnerAssetWriter writer,
-    Resolvers resolvers,
-    Stream terminateEventStream,
-    bool enableLowResourcesMode,
-    Map<String, String> outputMap,
-    bool outputSymlinksOnly,
-    bool trackPerformance,
-    bool skipBuildScriptCheck,
-    bool verbose,
-    bool isReleaseBuild,
-    Map<String, Map<String, dynamic>> builderConfigOverrides,
-    List<String> buildDirs,
-    String logPerformanceDir}) async {
-  builderConfigOverrides ??= const {};
-  packageGraph ??= PackageGraph.forThisPackage();
-  var environment = OverrideableEnvironment(
-      IOEnvironment(
-        packageGraph,
-        assumeTty: assumeTty,
-        outputMap: outputMap,
-        outputSymlinksOnly: outputSymlinksOnly,
-      ),
-      reader: reader,
-      writer: writer,
-      onLog: stdIOLogListener(assumeTty: assumeTty, verbose: verbose));
-  var logSubscription =
-      LogSubscription(environment, verbose: verbose);
-  var options = await BuildOptions.create(
-    logSubscription,
-    deleteFilesByDefault: deleteFilesByDefault,
-    packageGraph: packageGraph,
-    skipBuildScriptCheck: skipBuildScriptCheck,
-    overrideBuildConfig:
-        await findBuildConfigOverrides(packageGraph, configKey),
-    enableLowResourcesMode: enableLowResourcesMode,
-    trackPerformance: trackPerformance,
-    buildDirs: buildDirs,
-    logPerformanceDir: logPerformanceDir,
-    resolvers: resolvers,
-  );
-  var terminator = Terminator(terminateEventStream);
-  try {
-    var build = await BuildRunner.create(
-      options,
-      environment,
-      builders,
-      builderConfigOverrides,
-      isReleaseBuild: isReleaseBuild ?? false,
-    );
-    var result = await build.run({});
-    await build?.beforeExit();
-    return result;
-  } finally {
-    await terminator.cancel();
-    await options.logListener.cancel();
-  }
-}
 
 class ReflectableBuilder implements Builder {
   BuilderOptions builderOptions;
@@ -117,12 +50,29 @@ Future<BuildResult> reflectableBuild(List<String> arguments) async {
   } else {
     // TODO(eernst) feature: We should support some customization of
     // the settings, e.g., specifying options like `suppress_warnings`.
-    BuilderOptions options = new BuilderOptions(
+    var options = new BuilderOptions(
         <String, dynamic>{"entry_points": arguments, "formatted": true},
         isRoot: true);
     final builder = new ReflectableBuilder(options);
-    return await _build(
-        [applyToRoot(builder, generateFor: new InputSet(include: arguments))],
-        deleteFilesByDefault: true);
+    List<BuilderApplication> builders = [
+      applyToRoot(builder, generateFor: new InputSet(include: arguments))
+    ];
+    var packageGraph = PackageGraph.forThisPackage();
+    var environment = OverrideableEnvironment(IOEnvironment(packageGraph));
+    var buildOptions = await BuildOptions.create(
+      LogSubscription(environment),
+      deleteFilesByDefault: true,
+      packageGraph: packageGraph,
+    );
+    try {
+      var build = await BuildRunner.create(
+          buildOptions, environment, builders, const {},
+          isReleaseBuild: false);
+      var result = await build.run(const {});
+      await build?.beforeExit();
+      return result;
+    } finally {
+      await buildOptions.logListener.cancel();
+    }
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: reflectable
-version: 2.0.7
+version: 2.0.8
 description: >
   Reflection support based on code generation, using 'capabilities' to
   specify which operations to support, on which objects.
@@ -8,11 +8,11 @@ homepage: https://www.github.com/dart-lang/reflectable
 environment:
   sdk: '>=1.12.0 <3.0.0'
 dependencies:
-  analyzer: ^0.32.0
-  build: ^0.12.0
+  analyzer: ^0.33.0
+  build: ^1.0.0
   build_resolvers: ^0.2.0
   build_config: ^0.3.0
-  build_runner: ^0.10.0
+  build_runner: ^1.0.0
   dart_style: '>=0.2.0 <2.0.0'
   glob: ^1.1.0
   logging: ^0.11.0
@@ -22,4 +22,4 @@ dependencies:
   source_span: '>=1.0.0 <1.5.0'
 dev_dependencies:
   build_test: ^0.10.0
-  test: ^1.2.0
+  test: ^1.3.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   build_resolvers: ^0.2.0
   build_config: ^0.3.0
   build_runner: ^1.0.0
+  build_runner_core: ^1.0.0
   dart_style: '>=0.2.0 <2.0.0'
   glob: ^1.1.0
   logging: ^0.11.0


### PR DESCRIPTION
Flutter depends on `analyzer` 0.33 and that requires a newer `build` (which is now at version 1.0.x), so there's a need to switch to more current versions of several packages in reflectable.

This PR does that; the APIs exported from `build` changed a bit, so the implementation of the builder in `reflectable_builder.dart` had to change somewhat.

The version number has been updated to 2.0.8, such that we can publish this commit directly.