### PR TITLE
Updated analyzer dependency to allow 0.34.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.9
+
+* Updated dependency to allow using analyzer 0.34.
+
 ## 2.0.8+1
 
 * Corrected the email address listed in `pubspec.yaml` for Dart Team.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: reflectable
-version: 2.0.8+1
+version: 2.0.9
 description: >
   Reflection support based on code generation, using 'capabilities' to
   specify which operations to support, on which objects.
@@ -8,7 +8,7 @@ homepage: https://www.github.com/dart-lang/reflectable
 environment:
   sdk: '>=1.12.0 <3.0.0'
 dependencies:
-  analyzer: ^0.33.0
+  analyzer: '>=0.33.0 <0.35.0'
   build: ^1.0.0
   build_resolvers: ^0.2.0
   build_config: ^0.3.0


### PR DESCRIPTION
Cf. issue #159, the version update to allow `0.34.*` is needed for angular >=5.2.0.
This update should make reflectable ready for release as 2.0.9.

This causes a somewhat inconvenient change in the behavior of `build_runner`: It refuses to generate code incrementally (and it writes out a large warning about this). This affects clients (maybe even clients who don't know that they are using reflectable indirectly), and they must add a direct dependency on the analyzer (it is _not_ enough that reflectable has it). I've asked Jacob how to deal with this without asking every direct or indirect client out there to edit their pubspec.yaml and add `analyzer: any`. But I think it makes sense to respond to #159 without having resolved this issue, and then fix it when we know how to do that.

We could use version 2.0.8+2, given that we have now used 2.0.8+1 (and, maybe, those +k versions are the appropriate choice for small things, but it's not obvious to me that a dependency change on such a massive dependency as analyzer is a "small thing"). WDYT?