### PR TITLE
Pana fixes feb19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.0.10+1
 
-* Lint fixes (e.g., `var x;` rather than `var x = null;`).
+* Lint fixes (e.g., `T x;` rather than `T x = null;`).
 
 ## 2.0.10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.10+1
+
+* Lint fixes (e.g., `var x;` rather than `var x = null;`).
+
 ## 2.0.10
 
 * Updated dependency to allow using source_span 1.5.3.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -6,6 +6,23 @@ linter:
     - list_remove_unrelated_type
     - unrelated_type_equality_checks
     - valid_regexps
+    - avoid_empty_else
+    - avoid_init_to_null
+    - avoid_relative_lib_imports
+    - avoid_return_types_on_setters
+    - avoid_shadowing_type_parameters
+    - avoid_types_as_parameter_names
+    - empty_constructor_bodies
+    - no_duplicate_case_values
+    - null_closures
+    - prefer_contains
+    - prefer_equal_for_default_values
+    - prefer_is_empty
+    - prefer_is_not_empty
+    - recursive_getters
+    - slash_for_doc_comments
+    - unawaited_futures
+    - use_rethrow_when_possible
 analyzer:
   strong-mode:
     implicit-casts: true

--- a/lib/capability.dart
+++ b/lib/capability.dart
@@ -337,7 +337,7 @@ class SuperclassQuantifyCapability implements ReflecteeQuantifyCapability {
   final Type upperBound;
   final bool excludeUpperBound;
   const SuperclassQuantifyCapability(this.upperBound,
-      {bool excludeUpperBound: false})
+      {bool excludeUpperBound = false})
       : excludeUpperBound = excludeUpperBound;
 }
 
@@ -352,7 +352,7 @@ const superclassQuantifyCapability = const SuperclassQuantifyCapability(Object);
 /// etc.
 class TypeAnnotationQuantifyCapability implements ReflecteeQuantifyCapability {
   final bool transitive;
-  const TypeAnnotationQuantifyCapability({bool transitive: false})
+  const TypeAnnotationQuantifyCapability({bool transitive = false})
       : transitive = transitive;
 }
 
@@ -566,14 +566,14 @@ dynamic reflectableNoSuchInvokableError(
     List positionalArguments,
     Map<Symbol, dynamic> namedArguments,
     StringInvocationKind kind,
-    [List<Symbol> existingArgumentNames = null]) {
+    [List<Symbol> existingArgumentNames]) {
   throw new ReflectableNoSuchMethodError(receiver, memberName,
       positionalArguments, namedArguments, kind, existingArgumentNames);
 }
 
 dynamic reflectableNoSuchMethodError(Object receiver, String memberName,
     List positionalArguments, Map<Symbol, dynamic> namedArguments,
-    [List<Symbol> existingArgumentNames = null]) {
+    [List<Symbol> existingArgumentNames]) {
   throw new ReflectableNoSuchMethodError(
       receiver,
       memberName,
@@ -585,7 +585,7 @@ dynamic reflectableNoSuchMethodError(Object receiver, String memberName,
 
 dynamic reflectableNoSuchGetterError(Object receiver, String memberName,
     List positionalArguments, Map<Symbol, dynamic> namedArguments,
-    [List<Symbol> existingArgumentNames = null]) {
+    [List<Symbol> existingArgumentNames]) {
   throw new ReflectableNoSuchMethodError(
       receiver,
       memberName,
@@ -597,7 +597,7 @@ dynamic reflectableNoSuchGetterError(Object receiver, String memberName,
 
 dynamic reflectableNoSuchSetterError(Object receiver, String memberName,
     List positionalArguments, Map<Symbol, dynamic> namedArguments,
-    [List<Symbol> existingArgumentNames = null]) {
+    [List<Symbol> existingArgumentNames]) {
   throw new ReflectableNoSuchMethodError(
       receiver,
       memberName,
@@ -612,7 +612,7 @@ dynamic reflectableNoSuchConstructorError(
     String constructorName,
     List positionalArguments,
     Map<Symbol, dynamic> namedArguments,
-    [List<Symbol> existingArgumentNames = null]) {
+    [List<Symbol> existingArgumentNames]) {
   throw new ReflectableNoSuchMethodError(
       receiver,
       constructorName,

--- a/lib/reflectable.dart
+++ b/lib/reflectable.dart
@@ -99,16 +99,16 @@ abstract class Reflectable extends implementation.ReflectableImpl
   /// Const constructor, to enable usage as metadata, allowing for varargs
   /// style invocation with up to ten arguments.
   const Reflectable(
-      [ReflectCapability cap0 = null,
-      ReflectCapability cap1 = null,
-      ReflectCapability cap2 = null,
-      ReflectCapability cap3 = null,
-      ReflectCapability cap4 = null,
-      ReflectCapability cap5 = null,
-      ReflectCapability cap6 = null,
-      ReflectCapability cap7 = null,
-      ReflectCapability cap8 = null,
-      ReflectCapability cap9 = null])
+      [ReflectCapability cap0,
+      ReflectCapability cap1,
+      ReflectCapability cap2,
+      ReflectCapability cap3,
+      ReflectCapability cap4,
+      ReflectCapability cap5,
+      ReflectCapability cap6,
+      ReflectCapability cap7,
+      ReflectCapability cap8,
+      ReflectCapability cap9])
       : super(cap0, cap1, cap2, cap3, cap4, cap5, cap6, cap7, cap8, cap9);
 
   const Reflectable.fromList(List<ReflectCapability> capabilities)

--- a/lib/reflectable_builder.dart
+++ b/lib/reflectable_builder.dart
@@ -42,7 +42,7 @@ ReflectableBuilder reflectableBuilder(BuilderOptions options) {
 }
 
 Future<BuildResult> reflectableBuild(List<String> arguments) async {
-  if (arguments.length < 1) {
+  if (arguments.isEmpty) {
     // Globbing may produce an empty argument list, and it might be ok,
     // but we should give at least notify the caller.
     print("reflectable_builder: No arguments given, exiting.");

--- a/lib/src/builder_implementation.dart
+++ b/lib/src/builder_implementation.dart
@@ -296,7 +296,7 @@ class ClassElementEnhancedSet implements Set<ClassElement> {
   bool any(bool f(ClassElement element)) => classElements.items.any(f);
 
   @override
-  List<ClassElement> toList({bool growable: true}) {
+  List<ClassElement> toList({bool growable = true}) {
     return classElements.items.toList(growable: growable);
   }
 
@@ -691,6 +691,7 @@ class _ReflectorDomain {
         Iterable.generate(optionalPositionalCount, (int i) {
       ParameterElement parameterElement =
           constructor.parameters[requiredPositionalCount + i];
+      // ignore:deprecated_member_use
       FormalParameter parameterNode = parameterElement.computeNode();
       String defaultValueCode = "";
       if (parameterNode is DefaultFormalParameter &&
@@ -710,6 +711,7 @@ class _ReflectorDomain {
       // any named parameters then all optional parameters are named.
       ParameterElement parameterElement =
           constructor.parameters[requiredPositionalCount + i];
+      // ignore:deprecated_member_use
       FormalParameter parameterNode = parameterElement.computeNode();
       String defaultValueCode = "";
       if (parameterNode is DefaultFormalParameter &&
@@ -793,7 +795,7 @@ class _ReflectorDomain {
 
     // Class element for [Object], needed as implicit upper bound. Initialized
     // if needed.
-    ClassElement objectClassElement = null;
+    ClassElement objectClassElement;
 
     /// Adds a library domain for [library] to [libraries], relying on checks
     /// for importability and insertion into [importCollector] to have taken
@@ -1169,7 +1171,7 @@ class _ReflectorDomain {
       Map<FunctionType, int> typedefs) {
     if (dartType is ParameterizedType) {
       List<TypeParameterElement> typeParameters = dartType.typeParameters;
-      if (typeParameters.length == 0) {
+      if (typeParameters.isEmpty) {
         // We have no formal type parameters, so there cannot be any actual
         // type arguments.
         return 'const <int>[]';
@@ -1928,7 +1930,7 @@ class _ReflectorDomain {
                   typeVariablesInScope,
                   typedefs,
                   useNameOfGenericFunctionType: useNameOfGenericFunctionType));
-          String connector = argumentTypes.length == 0 ? "" : ", ";
+          String connector = argumentTypes.isEmpty ? "" : ", ";
           argumentTypes = "$argumentTypes$connector"
               "[${optionalParameterTypeList.join(', ')}]";
         }
@@ -1942,7 +1944,7 @@ class _ReflectorDomain {
                 useNameOfGenericFunctionType: useNameOfGenericFunctionType);
             return "$typeCode $name";
           });
-          String connector = argumentTypes.length == 0 ? "" : ", ";
+          String connector = argumentTypes.isEmpty ? "" : ", ";
           argumentTypes = "$argumentTypes$connector"
               "{${namedParameterTypeList.join(', ')}}";
         }
@@ -2185,6 +2187,7 @@ class _ReflectorDomain {
     }
     String metadataCode = "null";
     if (_capabilities._supportsMetadata) {
+      // ignore:deprecated_member_use
       FormalParameter node = element.computeNode();
       if (node == null) {
         metadataCode = "const []";
@@ -2193,6 +2196,7 @@ class _ReflectorDomain {
             element, _resolver, importCollector, _generatedLibraryId);
       }
     }
+    // ignore:deprecated_member_use
     FormalParameter parameterNode = element.computeNode();
     String defaultValueCode = "null";
     if (parameterNode is DefaultFormalParameter &&
@@ -2649,7 +2653,7 @@ class _ClassDomain {
             (member is PropertyAccessorElement && member.isSynthetic)
                 ? member.variable.metadata
                 : member.metadata;
-        List<ElementAnnotation> getterMetadata = null;
+        List<ElementAnnotation> getterMetadata;
         if (_reflectorDomain._capabilities._impliesCorrespondingSetters &&
             member is PropertyAccessorElement &&
             !member.isSynthetic &&
@@ -2723,7 +2727,7 @@ class _ClassDomain {
       // the metadata on the original field.
       List<ElementAnnotation> metadata =
           accessor.isSynthetic ? accessor.variable.metadata : accessor.metadata;
-      List<ElementAnnotation> getterMetadata = null;
+      List<ElementAnnotation> getterMetadata;
       if (_reflectorDomain._capabilities._impliesCorrespondingSetters &&
           accessor.isSetter &&
           !accessor.isSynthetic) {
@@ -3182,6 +3186,7 @@ class BuilderImplementation {
   /// [Reflectable].
   ClassElement _findReflectableClassElement(LibraryElement reflectableLibrary) {
     for (CompilationUnitElement unit in reflectableLibrary.units) {
+      // ignore:deprecated_member_use
       for (ClassElement type in unit.types) {
         if (type.name == reflectable_class_constants.name &&
             _equalsClassReflectable(type)) {
@@ -3477,6 +3482,7 @@ class BuilderImplementation {
       return false;
     }
     ConstructorDeclaration constructorDeclarationNode =
+        // ignore:deprecated_member_use
         constructor.computeNode();
     NodeList<ConstructorInitializer> initializers =
         constructorDeclarationNode.initializers;
@@ -3894,11 +3900,12 @@ class BuilderImplementation {
     }
 
     ConstructorDeclaration constructorDeclarationNode =
+        // ignore:deprecated_member_use
         constructorElement.computeNode();
     NodeList<ConstructorInitializer> initializers =
         constructorDeclarationNode.initializers;
 
-    if (initializers.length == 0) {
+    if (initializers.isEmpty) {
       // Degenerate case: Without initializers, we will obtain a reflector
       // without any capabilities, which is not useful in practice. We do
       // have this degenerate case in tests "just because we can", and
@@ -3949,7 +3956,7 @@ class BuilderImplementation {
           ? Uri.parse(originalEntryPointFilename)
           : _getImportUri(library, generatedLibraryId);
       String prefix = world.importCollector._getPrefix(library);
-      if (prefix.length > 0) {
+      if (prefix.isNotEmpty) {
         imports
             .add("import '$uri' as ${prefix.substring(0, prefix.length - 1)};");
       }
@@ -4320,6 +4327,7 @@ String _extractConstantCode(
         Element staticElement = expression.staticElement;
         if (staticElement is PropertyAccessorElement) {
           VariableElement variable = staticElement.variable;
+          // ignore:deprecated_member_use
           VariableDeclaration variableDeclaration = variable.computeNode();
           return helper(variableDeclaration.initializer);
         } else {
@@ -4436,6 +4444,7 @@ String _extractMetadataCode(Element element, Resolver resolver,
 
   List<String> metadataParts = <String>[];
 
+  // ignore:deprecated_member_use
   AstNode node = element.computeNode();
   if (node == null) {
     // This can occur with members of subclasses of `Element` from 'dart:html'.
@@ -4665,7 +4674,7 @@ Iterable<PropertyAccessorElement> _extractLibraryAccessors(Resolver resolver,
   for (CompilationUnitElement unit in libraryElement.units) {
     for (PropertyAccessorElement accessor in unit.accessors) {
       if (accessor.isPrivate) continue;
-      List<ElementAnnotation> metadata, getterMetadata = null;
+      List<ElementAnnotation> metadata, getterMetadata;
       if (accessor.isSynthetic) {
         metadata = accessor.variable.metadata;
         getterMetadata = metadata;
@@ -4708,7 +4717,7 @@ Iterable<PropertyAccessorElement> _extractAccessors(
         : capabilities.supportsInstanceInvoke;
     List<ElementAnnotation> metadata =
         accessor.isSynthetic ? accessor.variable.metadata : accessor.metadata;
-    List<ElementAnnotation> getterMetadata = null;
+    List<ElementAnnotation> getterMetadata;
     if (capabilities._impliesCorrespondingSetters &&
         accessor.isSetter &&
         !accessor.isSynthetic) {
@@ -4962,6 +4971,7 @@ class MixinApplication implements ClassElement {
 
   @override
   NamedCompilationUnitMember computeNode() =>
+      // ignore:deprecated_member_use
       declaredName != null ? subclass.computeNode() : null;
 
   @override
@@ -4983,7 +4993,6 @@ class MixinApplication implements ClassElement {
   int get hashCode => superclass.hashCode ^ mixin.hashCode ^ library.hashCode;
 
   toString() => "MixinApplication($superclass, $mixin)";
-
 
   // Let the compiler generate forwarders for all remaining methods: Instances
   // of this class are only ever passed around locally in this library, so
@@ -5136,6 +5145,7 @@ String _formatDiagnosticMessage(String message, Element target) {
   String locationString = "";
   int nameOffset = target.nameOffset;
   if (nameOffset != null) {
+    // ignore:deprecated_member_use
     var location = target.unit?.lineInfo?.getLocation(nameOffset);
     if (location != null) {
       locationString = "${location.lineNumber}:${location.columnNumber}";

--- a/lib/src/builder_implementation.dart
+++ b/lib/src/builder_implementation.dart
@@ -691,6 +691,7 @@ class _ReflectorDomain {
         Iterable.generate(optionalPositionalCount, (int i) {
       ParameterElement parameterElement =
           constructor.parameters[requiredPositionalCount + i];
+      // TODO(eernst): Work with Brian to find `computeNode` replacement.
       // ignore:deprecated_member_use
       FormalParameter parameterNode = parameterElement.computeNode();
       String defaultValueCode = "";
@@ -711,6 +712,7 @@ class _ReflectorDomain {
       // any named parameters then all optional parameters are named.
       ParameterElement parameterElement =
           constructor.parameters[requiredPositionalCount + i];
+      // TODO(eernst): Work with Brian to find `computeNode` replacement.
       // ignore:deprecated_member_use
       FormalParameter parameterNode = parameterElement.computeNode();
       String defaultValueCode = "";
@@ -2187,6 +2189,7 @@ class _ReflectorDomain {
     }
     String metadataCode = "null";
     if (_capabilities._supportsMetadata) {
+      // TODO(eernst): Work with Brian to find `computeNode` replacement.
       // ignore:deprecated_member_use
       FormalParameter node = element.computeNode();
       if (node == null) {
@@ -2196,6 +2199,7 @@ class _ReflectorDomain {
             element, _resolver, importCollector, _generatedLibraryId);
       }
     }
+    // TODO(eernst): Work with Brian to find `computeNode` replacement.
     // ignore:deprecated_member_use
     FormalParameter parameterNode = element.computeNode();
     String defaultValueCode = "null";
@@ -3186,6 +3190,7 @@ class BuilderImplementation {
   /// [Reflectable].
   ClassElement _findReflectableClassElement(LibraryElement reflectableLibrary) {
     for (CompilationUnitElement unit in reflectableLibrary.units) {
+      // TODO(eernst): Work with Brian to find `computeNode` replacement.
       // ignore:deprecated_member_use
       for (ClassElement type in unit.types) {
         if (type.name == reflectable_class_constants.name &&
@@ -3482,6 +3487,7 @@ class BuilderImplementation {
       return false;
     }
     ConstructorDeclaration constructorDeclarationNode =
+        // TODO(eernst): Work with Brian to find `computeNode` replacement.
         // ignore:deprecated_member_use
         constructor.computeNode();
     NodeList<ConstructorInitializer> initializers =
@@ -3900,6 +3906,7 @@ class BuilderImplementation {
     }
 
     ConstructorDeclaration constructorDeclarationNode =
+        // TODO(eernst): Work with Brian to find `computeNode` replacement.
         // ignore:deprecated_member_use
         constructorElement.computeNode();
     NodeList<ConstructorInitializer> initializers =
@@ -4327,6 +4334,7 @@ String _extractConstantCode(
         Element staticElement = expression.staticElement;
         if (staticElement is PropertyAccessorElement) {
           VariableElement variable = staticElement.variable;
+          // TODO(eernst): Work with Brian to find `computeNode` replacement.
           // ignore:deprecated_member_use
           VariableDeclaration variableDeclaration = variable.computeNode();
           return helper(variableDeclaration.initializer);
@@ -4444,6 +4452,7 @@ String _extractMetadataCode(Element element, Resolver resolver,
 
   List<String> metadataParts = <String>[];
 
+  // TODO(eernst): Work with Brian to find `computeNode` replacement.
   // ignore:deprecated_member_use
   AstNode node = element.computeNode();
   if (node == null) {
@@ -4971,6 +4980,7 @@ class MixinApplication implements ClassElement {
 
   @override
   NamedCompilationUnitMember computeNode() =>
+      // TODO(eernst): Work with Brian to find `computeNode` replacement.
       // ignore:deprecated_member_use
       declaredName != null ? subclass.computeNode() : null;
 
@@ -5145,6 +5155,7 @@ String _formatDiagnosticMessage(String message, Element target) {
   String locationString = "";
   int nameOffset = target.nameOffset;
   if (nameOffset != null) {
+    // TODO(eernst): Work with Brian to find `unit` replacement.
     // ignore:deprecated_member_use
     var location = target.unit?.lineInfo?.getLocation(nameOffset);
     if (location != null) {

--- a/lib/src/element_capability.dart
+++ b/lib/src/element_capability.dart
@@ -202,7 +202,7 @@ class SuperclassQuantifyCapability implements ReflecteeQuantifyCapability {
   final Element upperBound;
   final bool excludeUpperBound;
   const SuperclassQuantifyCapability(this.upperBound,
-      {bool excludeUpperBound: false})
+      {bool excludeUpperBound = false})
       : excludeUpperBound = excludeUpperBound;
 }
 
@@ -211,7 +211,7 @@ const superclassQuantifyCapability = const SuperclassQuantifyCapability(null);
 
 class TypeAnnotationQuantifyCapability implements ReflecteeQuantifyCapability {
   final bool transitive;
-  const TypeAnnotationQuantifyCapability({bool transitive: false})
+  const TypeAnnotationQuantifyCapability({bool transitive = false})
       : transitive = transitive;
 }
 

--- a/lib/src/reflectable_base.dart
+++ b/lib/src/reflectable_base.dart
@@ -55,16 +55,16 @@ class ReflectableBase {
   /// Const constructor, to enable usage as metadata, allowing for varargs
   /// style invocation with up to ten arguments.
   const ReflectableBase(
-      [this._cap0 = null,
-      this._cap1 = null,
-      this._cap2 = null,
-      this._cap3 = null,
-      this._cap4 = null,
-      this._cap5 = null,
-      this._cap6 = null,
-      this._cap7 = null,
-      this._cap8 = null,
-      this._cap9 = null])
+      [this._cap0,
+      this._cap1,
+      this._cap2,
+      this._cap3,
+      this._cap4,
+      this._cap5,
+      this._cap6,
+      this._cap7,
+      this._cap8,
+      this._cap9])
       : _capabilitiesGivenAsList = false,
         _capabilities = null;
 

--- a/lib/src/reflectable_builder_based.dart
+++ b/lib/src/reflectable_builder_based.dart
@@ -165,8 +165,7 @@ class ReflectorData {
   }
 }
 
-const String pleaseInitializeMessage =
-    "Reflectable has not been initialized.\n"
+const String pleaseInitializeMessage = "Reflectable has not been initialized.\n"
     "Please make sure that the first action taken by your program\n"
     "in `main` is to call `initializeReflectable()`.";
 
@@ -1159,7 +1158,8 @@ class InstantiatedGenericClassMirrorImpl extends ClassMirrorBase {
           "without `typeRelationsCapability`");
     }
     return reflectedTypeArguments
-        .map((Type type) => _reflector.reflectType(type)).toList();
+        .map((Type type) => _reflector.reflectType(type))
+        .toList();
   }
 
   @override
@@ -2467,16 +2467,16 @@ abstract class ReflectableImpl extends ReflectableBase
   /// Const constructor, to enable usage as metadata, allowing for varargs
   /// style invocation with up to ten arguments.
   const ReflectableImpl(
-      [ReflectCapability cap0 = null,
-      ReflectCapability cap1 = null,
-      ReflectCapability cap2 = null,
-      ReflectCapability cap3 = null,
-      ReflectCapability cap4 = null,
-      ReflectCapability cap5 = null,
-      ReflectCapability cap6 = null,
-      ReflectCapability cap7 = null,
-      ReflectCapability cap8 = null,
-      ReflectCapability cap9 = null])
+      [ReflectCapability cap0,
+      ReflectCapability cap1,
+      ReflectCapability cap2,
+      ReflectCapability cap3,
+      ReflectCapability cap4,
+      ReflectCapability cap5,
+      ReflectCapability cap6,
+      ReflectCapability cap7,
+      ReflectCapability cap8,
+      ReflectCapability cap9])
       : super(cap0, cap1, cap2, cap3, cap4, cap5, cap6, cap7, cap8, cap9);
 
   const ReflectableImpl.fromList(List<ReflectCapability> capabilities)
@@ -2522,7 +2522,7 @@ abstract class ReflectableImpl extends ReflectableBase
     // The specification says that an exception shall be thrown if there
     // is anything other than one library with a matching name.
     int matchCount = 0;
-    LibraryMirror matchingLibrary = null;
+    LibraryMirror matchingLibrary;
     for (LibraryMirror libraryMirror in reflectorData.libraryMirrors) {
       if (libraryMirror.qualifiedName == libraryName) {
         matchCount++;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: reflectable
-version: 2.0.10
+version: 2.0.10+1
 description: >
   Reflection support based on code generation, using 'capabilities' to
   specify which operations to support, on which objects.


### PR DESCRIPTION
The package pana (which is used to compute the 'health' of packages on pub.dartlang.org and similar metrics) is unhappy about a number of things (e.g., `T x = null;` should be `T x;` and `{bool myOptionalParameter: false}` should be `{bool myOptionalParameter = false}`). This PR makes the requested changes.

Note that it includes `// ignore:deprecated_member_use` in the locations where we are using `computeNode` and `unit`. Those problems are real, but it will take a little longer to resolve them. Basically, Brian says that there is more than one user of the AST layer (that is, not the `Element` layer) that the analyzer package has traditionally provided, so there will be ways to keep doing the things that reflectable does via this layer&mdash;but we can't do it right now.