### PR TITLE
Update reflectable to enable analyzer 0.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 * Major rewrite of the code generator in order to work with changes in the
   analyzer APIs, enabling the use of newer versions of many dependencies. In
-  particular, it enables analyzer 0.37.0. This addresses issue #173.
+  particular, it enables analyzer 0.37.0, which addresses issue #173. See
+  issue #180 about missing support for two features. This affects code in
+  platform libraries (that is, libraries imported with 'dart:...' except
+  'dart:ui'): If a declaration in a platform library has metadata, a query
+  for this metadata using `DeclarationMirror.metadata` will return null;
+  also, if a constructor in a platform library has a parameter with a default
+  value and that parameter is omitted in a reflective invocation, the value
+  passed will be `null` rather than the declared value.
 
 ## 2.0.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.0
+
+* Major rewrite of the code generator in order to work with changes in the
+  analyzer APIs, enabling the use of newer versions of many dependencies. In
+  particular, it enables analyzer 0.37.0. This addresses issue 173.
+
 ## 2.0.12
 
 * Follow-up bug fix related to #170: Corrected `ParameterMirror.defaultValue`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Major rewrite of the code generator in order to work with changes in the
   analyzer APIs, enabling the use of newer versions of many dependencies. In
-  particular, it enables analyzer 0.37.0. This addresses issue 173.
+  particular, it enables analyzer 0.37.0. This addresses issue #173.
 
 ## 2.0.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,17 @@
 ## 2.1.0
 
-* Major rewrite of the code generator in order to work with changes in the
-  analyzer APIs, enabling the use of newer versions of many dependencies. In
-  particular, it enables analyzer 0.37.0, which addresses issue #173. See
-  issue #180 about missing support for two features. This affects code in
-  platform libraries (that is, libraries imported with 'dart:...' except
-  'dart:ui'): If a declaration in a platform library has metadata, a query
-  for this metadata using `DeclarationMirror.metadata` will return null;
-  also, if a constructor in a platform library has a parameter with a default
-  value and that parameter is omitted in a reflective invocation, the value
-  passed will be `null` rather than the declared value.
+* Code generator rewritten in order to work with changes in the analyzer
+  APIs, enabling the use of analyzer version 0.37.0 (and newer versions of
+  many other packages), which addresses issue #173. See issue #180 about
+  missing support for two features: This affects code in platform libraries
+  (that is, libraries imported with 'dart:...' except 'dart:ui'). If a
+  declaration in a platform library has metadata, a query for this metadata
+  using `DeclarationMirror.metadata` will return null. Also, if a constructor
+  in a platform library has a parameter with a default value, and that
+  parameter is omitted in a reflective invocation, the value passed will be
+  `null` rather than the declared value. This is a bug, but it is blocked on
+  getting access to AST nodes in platform libraries from the resolver provided
+  by build.
 
 ## 2.0.12
 
@@ -45,8 +47,8 @@
 
 ## 2.0.7
 
-* Bug fix #132: We used to generate terms like `prefix2.di.inject` in order 
-  to denote a top level declaration named `inject`, but that's an error 
+* Bug fix #132: We used to generate terms like `prefix2.di.inject` in order
+  to denote a top level declaration named `inject`, but that's an error
   because `di` is an import prefix from client code. We now strip off such
   prefixes (yielding `prefix2.inject`) in the cases reported in issue #132.
 

--- a/codereview.settings
+++ b/codereview.settings
@@ -1,4 +1,0 @@
-# This file is used by gcl to get repository specific information.
-CODE_REVIEW_SERVER: http://codereview.chromium.org
-VIEW_VC: https://github.com/dart-lang/reflectable/commit/
-CC_LIST: eernst+reviews@google.com, reviews@dartlang.org

--- a/example/example.dart
+++ b/example/example.dart
@@ -19,7 +19,7 @@ class A {
   int arg0() => 42;
   int arg1(int x) => x - 42;
   int arg1to3(int x, int y, [int z = 0, w]) => x + y + z * 42;
-  int argNamed(int x, int y, {int z: 42}) => x + y - z;
+  int argNamed(int x, int y, {int z = 42}) => x + y - z;
   int operator +(x) => 42 + x;
   int operator [](x) => 42 + x;
   void operator []=(x, v) { f = x + v; }
@@ -31,7 +31,7 @@ class A {
   static int noArguments() => 42;
   static int oneArgument(x) => x - 42;
   static int optionalArguments(x, y, [z = 0, w]) => x + y + z * 42;
-  static int namedArguments(int x, int y, {int z: 42}) => x + y - z;
+  static int namedArguments(int x, int y, {int z = 42}) => x + y - z;
 }
 
 main() {

--- a/lib/reflectable_builder.dart
+++ b/lib/reflectable_builder.dart
@@ -24,7 +24,7 @@ class ReflectableBuilder implements Builder {
     var outputId = inputId.changeExtension('.reflectable.dart');
     List<LibraryElement> visibleLibraries = await resolver.libraries.toList();
     var generatedSource = await BuilderImplementation().buildMirrorLibrary(
-        resolver, inputId, outputId, inputLibrary, visibleLibraries, false, []);
+        resolver, inputId, outputId, inputLibrary, visibleLibraries, true, []);
     await buildStep.writeAsString(outputId, generatedSource);
   }
 

--- a/lib/reflectable_builder.dart
+++ b/lib/reflectable_builder.dart
@@ -22,12 +22,10 @@ class ReflectableBuilder implements Builder {
     var resolver = buildStep.resolver;
     var inputId = buildStep.inputId;
     var outputId = inputId.changeExtension('.reflectable.dart');
-    var resolvedInputLibrary = await resolver.libraryFor(inputId); // DEBUG
     List<LibraryElement> visibleLibraries = await resolver.libraries.toList();
-    await buildStep.writeAsString(
-        outputId,
-        new BuilderImplementation().buildMirrorLibrary(resolver, inputId,
-            outputId, inputLibrary, visibleLibraries, true, []));
+    var generatedSource = await BuilderImplementation().buildMirrorLibrary(
+        resolver, inputId, outputId, inputLibrary, visibleLibraries, false, []);
+    await buildStep.writeAsString(outputId, generatedSource);
   }
 
   Map<String, List<String>> get buildExtensions => const {

--- a/lib/reflectable_builder.dart
+++ b/lib/reflectable_builder.dart
@@ -18,10 +18,11 @@ class ReflectableBuilder implements Builder {
 
   @override
   Future<void> build(BuildStep buildStep) async {
+    var inputLibrary = await buildStep.inputLibrary;
     var resolver = buildStep.resolver;
     var inputId = buildStep.inputId;
     var outputId = inputId.changeExtension('.reflectable.dart');
-    var inputLibrary = await buildStep.inputLibrary;
+    var resolvedInputLibrary = await resolver.libraryFor(inputId); // DEBUG
     List<LibraryElement> visibleLibraries = await resolver.libraries.toList();
     await buildStep.writeAsString(
         outputId,

--- a/lib/reflectable_builder.dart
+++ b/lib/reflectable_builder.dart
@@ -23,7 +23,6 @@ class ReflectableBuilder implements Builder {
     var outputId = inputId.changeExtension('.reflectable.dart');
     var inputLibrary = await buildStep.inputLibrary;
     List<LibraryElement> visibleLibraries = await resolver.libraries.toList();
-
     await buildStep.writeAsString(
         outputId,
         new BuilderImplementation().buildMirrorLibrary(resolver, inputId,

--- a/lib/src/builder_implementation.dart
+++ b/lib/src/builder_implementation.dart
@@ -708,7 +708,7 @@ class _ReflectorDomain {
       String code = await _extractDefaultValueCode(
           importCollector, constructor.parameters[requiredPositionalCount + i]);
       String defaultPart = code.isEmpty ? "" : " = $code";
-      return "${namedParameterNames[i]}$defaultPart";
+      namedWithDefaultList.add("${namedParameterNames[i]}$defaultPart");
     }
     String namedWithDefaults = namedWithDefaultList.join(", ");
 
@@ -2202,20 +2202,20 @@ class _ReflectorDomain {
       // TODO(eernst): 'dart:*' is not considered valid. To survive, we
       // return the empty metadata for elements from 'dart:*'. Issue 173.
       if (_isPlatformLibrary(element.library)) {
-        return "const []";
-      }
-
-      var resolvedLibrary =
-          await element.session.getResolvedLibraryByElement(element.library);
-      var declaration = resolvedLibrary.getElementDeclaration(element);
-      // The declaration may be null because the element is synthetic, and
-      // then it has no metadata.
-      FormalParameter node = declaration?.node;
-      if (node == null) {
         metadataCode = "const []";
       } else {
-        metadataCode = await _extractMetadataCode(
-            element, _resolver, importCollector, _generatedLibraryId);
+        var resolvedLibrary =
+            await element.session.getResolvedLibraryByElement(element.library);
+        var declaration = resolvedLibrary.getElementDeclaration(element);
+        // The declaration may be null because the element is synthetic, and
+        // then it has no metadata.
+        FormalParameter node = declaration?.node;
+        if (node == null) {
+          metadataCode = "const []";
+        } else {
+          metadataCode = await _extractMetadataCode(
+              element, _resolver, importCollector, _generatedLibraryId);
+        }
       }
     }
     String code = await _extractDefaultValueCode(importCollector, element);

--- a/lib/src/builder_implementation.dart
+++ b/lib/src/builder_implementation.dart
@@ -973,25 +973,25 @@ class _ReflectorDomain {
 
     // Generate code for creation of class mirrors.
     List<String> typeMirrorsList = [];
-    for (_ClassDomain classDomain in (await classes).domains) {
-      typeMirrorsList.add(await _classMirrorCode(
-          classDomain,
-          typeParameters,
-          fields,
-          fieldsOffset,
-          methodsOffset,
-          typeParametersOffset,
-          members,
-          parameterListShapes,
-          parameterListShapeOf,
-          reflectedTypes,
-          reflectedTypesOffset,
-          libraries,
-          libraryMap,
-          importCollector,
-          typedefs));
-    }
     if (_capabilities._impliesTypes || _capabilities._impliesInstanceInvoke) {
+      for (_ClassDomain classDomain in (await classes).domains) {
+        typeMirrorsList.add(await _classMirrorCode(
+            classDomain,
+            typeParameters,
+            fields,
+            fieldsOffset,
+            methodsOffset,
+            typeParametersOffset,
+            members,
+            parameterListShapes,
+            parameterListShapeOf,
+            reflectedTypes,
+            reflectedTypesOffset,
+            libraries,
+            libraryMap,
+            importCollector,
+            typedefs));
+      }
       for (TypeParameterElement typeParameterElement in typeParameters.items) {
         typeMirrorsList.add(await _typeParameterMirrorCode(
             typeParameterElement, importCollector, objectClassElement));

--- a/lib/src/builder_implementation.dart
+++ b/lib/src/builder_implementation.dart
@@ -5054,6 +5054,12 @@ class MixinApplication implements ClassElement {
   @override
   get session => mixin.session;
 
+  @override
+  get source => mixin.source;
+
+  @override
+  get nameOffset => -1;
+
   /// Returns true iff this class was declared using the syntax
   /// `class B = A with M;`, i.e., if it is an explicitly named mixin
   /// application.
@@ -5098,7 +5104,7 @@ class MixinApplication implements ClassElement {
   // we will never need to support any members that we don't use locally.
   @override
   noSuchMethod(Invocation invocation) {
-    _severe("Missing MixinApplication member");
+    _severe("Missing MixinApplication member: ${invocation.memberName}");
   }
 }
 
@@ -5191,7 +5197,7 @@ Future<String> _formatDiagnosticMessage(String message, Element target) async {
     final resolvedLibrary =
         await target.session.getResolvedLibraryByElement(target.library);
     final targetDeclaration = resolvedLibrary.getElementDeclaration(target);
-    final unit = targetDeclaration.parsedUnit.unit;
+    final unit = targetDeclaration.resolvedUnit.unit;
     final location = unit.lineInfo?.getLocation(nameOffset);
     if (location != null) {
       locationString = "${location.lineNumber}:${location.columnNumber}";

--- a/lib/src/builder_implementation.dart
+++ b/lib/src/builder_implementation.dart
@@ -4,7 +4,6 @@
 
 library reflectable.src.builder_implementation;
 
-import 'dart:async';
 import 'dart:developer' as developer;
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/ast/ast.dart';

--- a/lib/src/builder_implementation.dart
+++ b/lib/src/builder_implementation.dart
@@ -2012,9 +2012,9 @@ class _ReflectorDomain {
         }
       }
     } else if (dartType is FunctionType) {
-      if (dartType.element.isPrivate) {
-        return 'const r.FakeType(r"${_qualifiedName(dartType.element)}")';
-      }
+      // A function type is inherently not private, so we ignore privacy.
+      // Note that some function types are _claimed_ to be private in analyzer
+      // 0.36.4, so it is a bug to test for it.
       if (dartType.element is FunctionTypeAliasElement) {
         FunctionTypeAliasElement element = dartType.element;
         String prefix = importCollector._getPrefix(element.library);

--- a/lib/src/builder_implementation.dart
+++ b/lib/src/builder_implementation.dart
@@ -993,8 +993,8 @@ class _ReflectorDomain {
     }
     if (_capabilities._impliesTypes || _capabilities._impliesInstanceInvoke) {
       for (TypeParameterElement typeParameterElement in typeParameters.items) {
-        await _typeParameterMirrorCode(
-            typeParameterElement, importCollector, objectClassElement);
+        typeMirrorsList.add(await _typeParameterMirrorCode(
+            typeParameterElement, importCollector, objectClassElement));
       }
     }
     String classMirrorsCode = _formatAsList("m.TypeMirror", typeMirrorsList);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,16 +10,16 @@ environment:
 dependencies:
   analyzer: '>=0.36.0 <0.38.0'
   build: ^1.1.0
-  build_resolvers: '>=1.0.0 <2.0.0'
+  build_resolvers: ^1.0.0
   build_config: ^0.4.0
   build_runner: ^1.6.0
   build_runner_core: ^3.0.0
-  dart_style: '>=1.2.0 <2.0.0'
+  dart_style: ^1.2.0
   glob: ^1.1.0
   logging: ^0.11.0
   package_config: ^1.0.0
   package_resolver: ^1.0.0
-  path: '>=1.6.0 <2.0.0'
+  path: ^1.6.0
   source_span: ^1.5.0
 dev_dependencies:
   build_test: ^0.10.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ description: >
 author: Dart Team <misc@dartlang.org>
 homepage: https://www.github.com/dart-lang/reflectable
 environment:
-  sdk: '>=1.12.0 <3.0.0'
+  sdk: '>=2.3.0 <3.0.0'
 dependencies:
   analyzer: '>=0.36.0 <0.38.0'
   build: ^1.1.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,19 +8,19 @@ homepage: https://www.github.com/dart-lang/reflectable
 environment:
   sdk: '>=1.12.0 <3.0.0'
 dependencies:
-  analyzer: '>=0.35.0 <0.37.0'
-  build: any # ^1.0.0 DEBUG
-  build_resolvers: any # '>=0.2.0 <2.0.0' DEBUG
-  build_config: any # ^0.3.0 DEBUG
-  build_runner: any # ^1.3.0 DEBUG
-  build_runner_core: any # ^3.0.0 DEBUG
-  dart_style: any # '>=0.2.0 <2.0.0' DEBUG
-  glob: any # ^1.1.0 DEBUG
-  logging: any # ^0.11.0 DEBUG
-  package_config: any # ^1.0.0 DEBUG
-  package_resolver: any # ^1.0.0 DEBUG
-  path: any # '>=1.2.0 <2.0.0' DEBUG
-  source_span: any # ^1.0.0 DEBUG
+  analyzer: '>=0.36.0 <0.38.0'
+  build: ^1.1.0
+  build_resolvers: '>=1.0.0 <2.0.0'
+  build_config: ^0.4.0
+  build_runner: ^1.6.0
+  build_runner_core: ^3.0.0
+  dart_style: '>=1.2.0 <2.0.0'
+  glob: ^1.1.0
+  logging: ^0.11.0
+  package_config: ^1.0.0
+  package_resolver: ^1.0.0
+  path: '>=1.6.0 <2.0.0'
+  source_span: ^1.5.0
 dev_dependencies:
-  build_test: any # ^0.10.0 DEBUG
-  test: any # ^1.3.0 DEBUG
+  build_test: ^0.10.0
+  test: ^1.5.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,18 +9,18 @@ environment:
   sdk: '>=1.12.0 <3.0.0'
 dependencies:
   analyzer: '>=0.35.0 <0.37.0'
-  build: ^1.0.0
-  build_resolvers: '>=0.2.0 <2.0.0'
-  build_config: ^0.3.0
-  build_runner: ^1.3.0
-  build_runner_core: ^3.0.0
-  dart_style: '>=0.2.0 <2.0.0'
-  glob: ^1.1.0
-  logging: ^0.11.0
-  package_config: ^1.0.0
-  package_resolver: ^1.0.0
-  path: '>=1.2.0 <2.0.0'
-  source_span: ^1.0.0
+  build: any # ^1.0.0 DEBUG
+  build_resolvers: any # '>=0.2.0 <2.0.0' DEBUG
+  build_config: any # ^0.3.0 DEBUG
+  build_runner: any # ^1.3.0 DEBUG
+  build_runner_core: any # ^3.0.0 DEBUG
+  dart_style: any # '>=0.2.0 <2.0.0' DEBUG
+  glob: any # ^1.1.0 DEBUG
+  logging: any # ^0.11.0 DEBUG
+  package_config: any # ^1.0.0 DEBUG
+  package_resolver: any # ^1.0.0 DEBUG
+  path: any # '>=1.2.0 <2.0.0' DEBUG
+  source_span: any # ^1.0.0 DEBUG
 dev_dependencies:
-  build_test: ^0.10.0
-  test: ^1.3.0
+  build_test: any # ^0.10.0 DEBUG
+  test: any # ^1.3.0 DEBUG

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: reflectable
-version: 2.0.12
+version: 2.1.0
 description: >
   Reflection support based on code generation, using 'capabilities' to
   specify which operations to support, on which objects.
@@ -8,12 +8,12 @@ homepage: https://www.github.com/dart-lang/reflectable
 environment:
   sdk: '>=1.12.0 <3.0.0'
 dependencies:
-  analyzer: ^0.35.4
+  analyzer: '>=0.35.0 <0.37.0'
   build: ^1.0.0
   build_resolvers: '>=0.2.0 <2.0.0'
   build_config: ^0.3.0
-  build_runner: ^1.0.0
-  build_runner_core: '>=1.0.0 <3.0.0'
+  build_runner: ^1.3.0
+  build_runner_core: ^3.0.0
   dart_style: '>=0.2.0 <2.0.0'
   glob: ^1.1.0
   logging: ^0.11.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ homepage: https://www.github.com/dart-lang/reflectable
 environment:
   sdk: '>=1.12.0 <3.0.0'
 dependencies:
-  analyzer: '>=0.33.0 <0.35.0'
+  analyzer: ^0.35.4
   build: ^1.0.0
   build_resolvers: '>=0.2.0 <2.0.0'
   build_config: ^0.3.0

--- a/tool/publish
+++ b/tool/publish
@@ -5,15 +5,12 @@
 # the LICENSE file.
 
 warning_at_entry () {
-  echo 'NB: This script is highly specialized, it is only intended to be used'
-  echo 'when a new version of the reflectable package is being published.'
-  echo 'The procedure can be stopped at every step by pressing ^C rather'
-  echo 'than [ENTER].'
-  echo
+  echo 'NB: This script shows the steps to take in order to publish a new'
+  echo 'version of reflectable, and assigns values to some variables; the'
+  echo 'steps must then be taken manually.'
 }
 
 usage () {
-  warning_at_entry
   echo "Usage:"
   echo "  $0 [--help|-h] [<new-version>]"
   echo "where <new-version> = <major-number>.<minor-number>.<patch-number>"
@@ -52,17 +49,6 @@ if [[ ! `pwd` =~ /tool$ ]]; then
   exit -1
 fi
 
-if git status | head -1 | grep master >/dev/null; then
-  echo "On branch master; please create a fresh branch for publishing."
-  exit -1
-fi
-
-if [ "`git diff master | wc -l`" -ne "0" ]; then
-  echo "On a branch that differs from master; please create a fresh"
-  echo "branch for publishing."
-  exit -1
-fi
-
 MAJOR="${1%%.*}"
 MINOR="${1#*.}"; MINOR="${MINOR%.*}"
 PATCH="${1##*.}"
@@ -79,24 +65,18 @@ COMMIT_MESSAGE="'Bumping version to $VERSION'"
 TAG_MESSAGE="'Released as version $VERSION'"
 
 echo "Using tag value '$TAG_VALUE'."
-echo -n "Update CHANGELOG.md and then press [ENTER] here to see the diff.. "
+echo -n "Check entry in CHANGELOG.md and version in pubspec.yaml: $VERSION"
 read
 
-edit_version ../pubspec.yaml $VERSION
+echo ">>>>>> Ensure that github master is the version to publish"
+read
 
-git diff HEAD
-
-( cd ..; pub publish --dry-run )
-echo ">>>>>> Run these commands:"
-echo git add --all
-echo git commit -m$COMMIT_MESSAGE
-echo git push --set-upstream origin "current_branch_name"
-echo ">>>>>> Please get review such that these changes can be landed.. "
-echo ">>>>>> Merge the PR on github"
+echo ">>>>>> Then publish as follows:"
 echo git co master
-echo git pull --rebase origin master
+echo git fetch origin
+echo git pull
 echo pushd ..
 echo pub publish
-echo git tag -a -m$TAG_MESSAGE $TAG_VALUE
-echo git push origin refs/tags/$TAG_VALUE:refs/tags/$TAG_VALUE
+echo git tag -a -m"$TAG_MESSAGE" "$TAG_VALUE"
+echo git push origin refs/tags/${TAG_VALUE}:refs/tags/$TAG_VALUE
 echo popd


### PR DESCRIPTION
Cf. issue #173: Code generator updated to use new APIs for access to abstract syntax (`AstNode`) entities (`computeNode` cannot be used any more). This involves a major element of asynchrony, hence there are many changes of functions to be `async`, and of expressions to `await` a result.

The analyzer-as-used-by-build relies on summaries (rather than full libraries) for platform libraries ('dart:...' except 'dart:ui'). This means that it is not possible to obtain information about non-signature properties of platform code. See issue #180 for more details.

Note that the changes in `reflectable_builder.dart` were made to use the control flow shown in `build` package documentation.

This PR introduces a new version number: 2.1.0. This PR is the biggest rewrite of reflectable since 2016 (so it seems misleading to call it 2.0.13), but it is only a breaking change in the sense that clients may not admit the updated versions of various dependencies. This will not actually break clients, they will just stay on 2.0.12 until they are ready to admit the updates&mdash;hence there's no need to go to 3.0.0.