### PR TITLE
Use pedantic lints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.2.0
+
+* Adjust implementation to satisfy 'pedantic' lints. The generated code
+  does this as well, except that some `const` modifiers are generated even
+  though they could be omitted (an `// ignore_for_file` comment is generated
+  such that the linter does not complain about this). Upgrade dependencies
+  to allow using analyzer 0.38.5, and current versions of many other packages.
+
 ## 2.1.0
 
 * Code generator rewritten in order to work with changes in the analyzer

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,28 +1,7 @@
+include: package:pedantic/analysis_options.yaml
 linter:
   rules:
-    - camel_case_types
-    - hash_and_equals
-    - iterable_contains_unrelated_type
-    - list_remove_unrelated_type
-    - unrelated_type_equality_checks
-    - valid_regexps
-    - avoid_empty_else
-    - avoid_init_to_null
-    - avoid_relative_lib_imports
-    - avoid_return_types_on_setters
-    - avoid_shadowing_type_parameters
-    - avoid_types_as_parameter_names
-    - empty_constructor_bodies
-    - no_duplicate_case_values
-    - null_closures
-    - prefer_contains
-    - prefer_equal_for_default_values
-    - prefer_is_empty
-    - prefer_is_not_empty
-    - recursive_getters
-    - slash_for_doc_comments
-    - unawaited_futures
-    - use_rethrow_when_possible
+    - await_only_futures
 analyzer:
   strong-mode:
     implicit-casts: true

--- a/example/example.dart
+++ b/example/example.dart
@@ -40,7 +40,7 @@ main() {
   initializeReflectable();
 
   // Get hold of a few mirrors.
-  A instance = new A();
+  A instance = A();
   InstanceMirror instanceMirror = myReflectable.reflect(instance);
   ClassMirror classMirror = myReflectable.reflectType(A);
 

--- a/example/example.dart
+++ b/example/example.dart
@@ -12,7 +12,7 @@ class MyReflectable extends Reflectable {
   const MyReflectable() : super(invokingCapability);
 }
 
-const myReflectable = const MyReflectable();
+const myReflectable = MyReflectable();
 
 @myReflectable
 class A {

--- a/lib/capability.dart
+++ b/lib/capability.dart
@@ -95,7 +95,7 @@ class InstanceInvokeCapability extends NamePatternCapability {
 
 /// Short hand for `InstanceInvokeCapability("")`, meaning the capability to
 /// reflect over all instance members.
-const instanceInvokeCapability = const InstanceInvokeCapability("");
+const instanceInvokeCapability = InstanceInvokeCapability("");
 
 /// Gives support for reflective invocation of instance members (methods,
 /// getters, and setters) annotated with instances of [metadataType] or a
@@ -114,7 +114,7 @@ class StaticInvokeCapability extends NamePatternCapability
 
 /// Short hand for `StaticInvokeCapability("")`, meaning the capability to
 /// reflect over all static members.
-const staticInvokeCapability = const StaticInvokeCapability("");
+const staticInvokeCapability = StaticInvokeCapability("");
 
 /// Gives support for reflective invocation of static members (static methods,
 /// getters, and setters) that are annotated with instances of [metadataType]
@@ -133,7 +133,7 @@ class TopLevelInvokeCapability extends NamePatternCapability {
 
 /// Short hand for `TopLevelInvokeCapability("")`, meaning the capability to
 /// reflect over all top-level members.
-const topLevelInvokeCapability = const TopLevelInvokeCapability("");
+const topLevelInvokeCapability = TopLevelInvokeCapability("");
 
 /// Gives support for reflective invocation of top-level members (top-level
 /// methods, getters, and setters) that are annotated with instances of
@@ -156,7 +156,7 @@ class NewInstanceCapability extends NamePatternCapability
 
 /// Short hand for `const NewInstanceCapability("")`, meaning the capability to
 /// reflect over all constructors.
-const newInstanceCapability = const NewInstanceCapability("");
+const newInstanceCapability = NewInstanceCapability("");
 
 /// Gives support for reflective invocation
 /// of constructors (of all kinds) annotated by instances of [metadataType]
@@ -173,7 +173,7 @@ class MetadataCapability implements TypeCapability {
 }
 
 /// Shorthand for `const MetadataCapability()`.
-const metadataCapability = const MetadataCapability();
+const metadataCapability = MetadataCapability();
 
 /// Gives support for invocation of the method `reflectType` on reflectors, and
 /// for invocation of the method `type` on instances of `InstanceMirror` and
@@ -193,7 +193,7 @@ class TypeCapability implements ApiReflectCapability {
 }
 
 /// Shorthand for `const TypeCapability()`.
-const typeCapability = const TypeCapability();
+const typeCapability = TypeCapability();
 
 /// Gives support for: `typeVariables`, `typeArguments`,
 /// `originalDeclaration`, `isSubtypeOf`, `isAssignableTo`, `superclass`,
@@ -203,12 +203,12 @@ class TypeRelationsCapability implements TypeCapability {
 }
 
 /// Shorthand for `const TypeRelationsCapability()`.
-const typeRelationsCapability = const TypeRelationsCapability();
+const typeRelationsCapability = TypeRelationsCapability();
 
 /// Gives support for the method `reflectedType` on `VariableMirror` and
 /// `ParameterMirror`, and for the method `reflectedReturnType` on
 /// `MethodMirror`.
-const reflectedTypeCapability = const _ReflectedTypeCapability();
+const reflectedTypeCapability = _ReflectedTypeCapability();
 
 /// Gives support for library-mirrors.
 ///
@@ -223,7 +223,7 @@ class LibraryCapability implements ApiReflectCapability {
 }
 
 /// Shorthand for `const LibraryCapability()`.
-const libraryCapability = const LibraryCapability();
+const libraryCapability = LibraryCapability();
 
 /// Gives support for: `declarations`, `instanceMembers`, `staticMembers`,
 /// `callMethod`, `parameters`, and `defaultValue`.
@@ -237,7 +237,7 @@ class DeclarationsCapability implements TypeCapability {
 }
 
 /// Shorthand for `const DeclarationsCapability()`.
-const declarationsCapability = const DeclarationsCapability();
+const declarationsCapability = DeclarationsCapability();
 
 /// Gives support for the mirror method `uri` on LibraryMirrors.
 class UriCapability implements LibraryCapability {
@@ -245,7 +245,7 @@ class UriCapability implements LibraryCapability {
 }
 
 /// Shorthand for `const UriCapability()`.
-const uriCapability = const UriCapability();
+const uriCapability = UriCapability();
 
 /// Gives support for: `sourceLibrary`, `targetLibrary`, `prefix`, and
 /// `combinators`.
@@ -254,7 +254,7 @@ class LibraryDependenciesCapability implements LibraryCapability {
 }
 
 /// Shorthand for `const LibraryDependenciesCapability()`.
-const libraryDependenciesCapability = const LibraryDependenciesCapability();
+const libraryDependenciesCapability = LibraryDependenciesCapability();
 
 /// Gives all the capabilities of [InstanceInvokeCapability]([namePattern]),
 /// [StaticInvokeCapability]([namePattern]), and
@@ -269,7 +269,7 @@ class InvokingCapability extends NamePatternCapability
 
 /// Short hand for `InvokingCapability("")`, meaning the capability to
 /// reflect over all top-level and static members.
-const invokingCapability = const InvokingCapability("");
+const invokingCapability = InvokingCapability("");
 
 /// Gives the capabilities of all the capabilities requested by
 /// [InstanceInvokeMetaCapability]([metadata]),
@@ -298,13 +298,13 @@ class TypingCapability
 }
 
 /// Shorthand for `const TypingCapability()`.
-const typingCapability = const TypingCapability();
+const typingCapability = TypingCapability();
 
 /// Capability instance giving support for the `delegate` method on instance
 /// mirrors when it leads to invocation of a method where instance invocation
 /// is supported. Also implies support for translation of [Symbol]s of covered
 /// members to their corresponding [String]s.
-const delegateCapability = const _DelegateCapability();
+const delegateCapability = _DelegateCapability();
 
 // ---------- Reflectee quantification oriented capability classes.
 
@@ -326,7 +326,7 @@ abstract class ReflecteeQuantifyCapability implements ReflectCapability {
 ///
 /// Note that this is applied before `superclassQuantifyCapability` and before
 /// any `TypeAnnotationQuantifyCapability`.
-const subtypeQuantifyCapability = const _SubtypeQuantifyCapability();
+const subtypeQuantifyCapability = _SubtypeQuantifyCapability();
 
 /// Gives support for reflection on all superclasses of covered classes up to
 /// [upperBound]
@@ -344,7 +344,7 @@ class SuperclassQuantifyCapability implements ReflecteeQuantifyCapability {
 /// Gives support for reflection on all superclasses of covered classes.
 ///
 /// Short for: `const SuperclassQuantifyCapability(Object)`.
-const superclassQuantifyCapability = const SuperclassQuantifyCapability(Object);
+const superclassQuantifyCapability = SuperclassQuantifyCapability(Object);
 
 /// Gives support for reflecting on the classes used as type annotations
 /// of covered methods, parameters and fields. If [transitive] is true the
@@ -360,8 +360,7 @@ class TypeAnnotationQuantifyCapability implements ReflecteeQuantifyCapability {
 /// of covered methods, parameters and fields.
 ///
 /// Short for `const TypeAnnotationQuantifyCapability()`.
-const typeAnnotationQuantifyCapability =
-    const TypeAnnotationQuantifyCapability();
+const typeAnnotationQuantifyCapability = TypeAnnotationQuantifyCapability();
 
 /// Gives support for reflecting on the full closure of type annotations
 /// of covered methods/parameters.
@@ -374,13 +373,13 @@ const typeAnnotationQuantifyCapability =
 /// including classes used as type annotations in classes used as type
 /// annotations, etc.).
 const typeAnnotationDeepQuantifyCapability =
-    const TypeAnnotationQuantifyCapability(transitive: true);
+    TypeAnnotationQuantifyCapability(transitive: true);
 
 /// Quantifying capability instance specifying that the reflection support
 /// for any given explicitly declared getter must also be given to its
 /// corresponding explicitly declared setter, if any.
 const correspondingSetterQuantifyCapability =
-    const _CorrespondingSetterQuantifyCapability();
+    _CorrespondingSetterQuantifyCapability();
 
 /// Gives support for calling `.reflect` on subtypes of covered instances.
 ///
@@ -404,7 +403,7 @@ const correspondingSetterQuantifyCapability =
 /// For more information about this potentially dangerous device, please
 /// refer to the design document.
 /// TODO(eernst) doc: Insert a link to the design document.
-const admitSubtypeCapability = const _AdmitSubtypeCapability();
+const admitSubtypeCapability = _AdmitSubtypeCapability();
 
 /// Abstract superclass for all capabilities which are used to specify
 /// that a given reflector must be considered to be applied as metadata
@@ -521,8 +520,8 @@ class ReflectableNoSuchMethodError extends Error
       this.kind,
       this.existingArgumentNames);
 
-  get invocation => new _StringInvocation(
-      memberName, positionalArguments, namedArguments, kind);
+  get invocation =>
+      _StringInvocation(memberName, positionalArguments, namedArguments, kind);
 
   toString() {
     String kindName;
@@ -567,44 +566,29 @@ dynamic reflectableNoSuchInvokableError(
     Map<Symbol, dynamic> namedArguments,
     StringInvocationKind kind,
     [List<Symbol> existingArgumentNames]) {
-  throw new ReflectableNoSuchMethodError(receiver, memberName,
-      positionalArguments, namedArguments, kind, existingArgumentNames);
+  throw ReflectableNoSuchMethodError(receiver, memberName, positionalArguments,
+      namedArguments, kind, existingArgumentNames);
 }
 
 dynamic reflectableNoSuchMethodError(Object receiver, String memberName,
     List positionalArguments, Map<Symbol, dynamic> namedArguments,
     [List<Symbol> existingArgumentNames]) {
-  throw new ReflectableNoSuchMethodError(
-      receiver,
-      memberName,
-      positionalArguments,
-      namedArguments,
-      StringInvocationKind.method,
-      existingArgumentNames);
+  throw ReflectableNoSuchMethodError(receiver, memberName, positionalArguments,
+      namedArguments, StringInvocationKind.method, existingArgumentNames);
 }
 
 dynamic reflectableNoSuchGetterError(Object receiver, String memberName,
     List positionalArguments, Map<Symbol, dynamic> namedArguments,
     [List<Symbol> existingArgumentNames]) {
-  throw new ReflectableNoSuchMethodError(
-      receiver,
-      memberName,
-      positionalArguments,
-      namedArguments,
-      StringInvocationKind.getter,
-      existingArgumentNames);
+  throw ReflectableNoSuchMethodError(receiver, memberName, positionalArguments,
+      namedArguments, StringInvocationKind.getter, existingArgumentNames);
 }
 
 dynamic reflectableNoSuchSetterError(Object receiver, String memberName,
     List positionalArguments, Map<Symbol, dynamic> namedArguments,
     [List<Symbol> existingArgumentNames]) {
-  throw new ReflectableNoSuchMethodError(
-      receiver,
-      memberName,
-      positionalArguments,
-      namedArguments,
-      StringInvocationKind.setter,
-      existingArgumentNames);
+  throw ReflectableNoSuchMethodError(receiver, memberName, positionalArguments,
+      namedArguments, StringInvocationKind.setter, existingArgumentNames);
 }
 
 dynamic reflectableNoSuchConstructorError(
@@ -613,7 +597,7 @@ dynamic reflectableNoSuchConstructorError(
     List positionalArguments,
     Map<Symbol, dynamic> namedArguments,
     [List<Symbol> existingArgumentNames]) {
-  throw new ReflectableNoSuchMethodError(
+  throw ReflectableNoSuchMethodError(
       receiver,
       constructorName,
       positionalArguments,

--- a/lib/reflectable_builder.dart
+++ b/lib/reflectable_builder.dart
@@ -34,9 +34,9 @@ class ReflectableBuilder implements Builder {
 }
 
 ReflectableBuilder reflectableBuilder(BuilderOptions options) {
-  var config = new Map<String, Object>.from(options.config);
+  var config = Map<String, Object>.from(options.config);
   config.putIfAbsent('entry_points', () => ['**.dart']);
-  return new ReflectableBuilder(options);
+  return ReflectableBuilder(options);
 }
 
 Future<BuildResult> reflectableBuild(List<String> arguments) async {
@@ -44,16 +44,16 @@ Future<BuildResult> reflectableBuild(List<String> arguments) async {
     // Globbing may produce an empty argument list, and it might be ok,
     // but we should give at least notify the caller.
     print("reflectable_builder: No arguments given, exiting.");
-    return new BuildResult(BuildStatus.success, []);
+    return BuildResult(BuildStatus.success, []);
   } else {
     // TODO(eernst) feature: We should support some customization of
     // the settings, e.g., specifying options like `suppress_warnings`.
-    var options = new BuilderOptions(
+    var options = BuilderOptions(
         <String, dynamic>{"entry_points": arguments, "formatted": true},
         isRoot: true);
-    final builder = new ReflectableBuilder(options);
+    final builder = ReflectableBuilder(options);
     List<BuilderApplication> builders = [
-      applyToRoot(builder, generateFor: new InputSet(include: arguments))
+      applyToRoot(builder, generateFor: InputSet(include: arguments))
     ];
     var packageGraph = PackageGraph.forThisPackage();
     var environment = OverrideableEnvironment(IOEnvironment(packageGraph));

--- a/lib/src/builder_implementation.dart
+++ b/lib/src/builder_implementation.dart
@@ -266,7 +266,11 @@ class ClassElementEnhancedSet implements Set<ClassElement> {
 
   @override
   Iterable<T> whereType<T>() sync* {
-    for (var element in this) if (element is T) yield (element as T);
+    for (var element in this) {
+      if (element is T) {
+        yield (element as T);
+      }
+    }
   }
 
   @override
@@ -646,7 +650,7 @@ class _ReflectorDomain {
   /// This is to provide something that can be called with [Function.apply].
   ///
   /// For example for a constructor Foo(x, {y: 3}):
-  /// returns "(x, {y: 3}) => new prefix1.Foo(x, y)", and records an import of
+  /// returns "(x, {y: 3}) => prefix1.Foo(x, y)", and records an import of
   /// the library of `Foo` associated with prefix1 in [importCollector].
   Future<String> _constructorCode(
       ConstructorElement constructor, _ImportCollector importCollector) async {
@@ -740,7 +744,7 @@ class _ReflectorDomain {
 
     String prefix = importCollector._getPrefix(constructor.library);
     return ('($doRunArgument) => (${parameterParts.join(', ')}) => '
-        '$doRunArgument ? new $prefix${await _nameOfConstructor(constructor)}'
+        '$doRunArgument ? $prefix${await _nameOfConstructor(constructor)}'
         '(${argumentParts.join(", ")}) : null');
   }
 
@@ -804,8 +808,10 @@ class _ReflectorDomain {
     /// Used to add a library domain for [library] to [libraries], checking
     /// that it is importable and registering it with [importCollector].
     Future<void> addLibrary(LibraryElement library) async {
-      if (!await _isImportableLibrary(library, _generatedLibraryId, _resolver))
+      if (!await _isImportableLibrary(
+          library, _generatedLibraryId, _resolver)) {
         return;
+      }
       importCollector._addLibrary(library);
       uncheckedAddLibrary(library);
     }
@@ -1109,7 +1115,7 @@ class _ReflectorDomain {
         .items
         .map((ParameterListShape shape) => shape.code));
 
-    return "new r.ReflectorData($classMirrorsCode, $membersCode, "
+    return "r.ReflectorData($classMirrorsCode, $membersCode, "
         "$parameterMirrorsCode, $typesCode, $reflectedTypesOffset, "
         "$gettersCode, $settersCode, $librariesCode, "
         "$parameterListShapesCode)";
@@ -1280,7 +1286,7 @@ class _ReflectorDomain {
     // TODO(eernst) implement: Update when type variables support metadata.
     String metadataCode =
         _capabilities._supportsMetadata ? "<Object>[]" : "null";
-    return 'new r.TypeVariableMirrorImpl(r"${typeParameterElement.name}", '
+    return 'r.TypeVariableMirrorImpl(r"${typeParameterElement.name}", '
         'r"${_qualifiedTypeParameterName(typeParameterElement)}", '
         '${await _constConstructionCode(importCollector)}, '
         '$upperBoundIndex, $ownerIndex, $metadataCode)';
@@ -1483,7 +1489,7 @@ class _ReflectorDomain {
     }
 
     if (classElement.typeParameters.isEmpty) {
-      return 'new r.NonGenericClassMirrorImpl(r"${classDomain._simpleName}", '
+      return 'r.NonGenericClassMirrorImpl(r"${classDomain._simpleName}", '
           'r"${_qualifiedName(classElement)}", $descriptor, $classIndex, '
           '${await _constConstructionCode(importCollector)}, '
           '$declarationsCode, $instanceMembersCode, $staticMembersCode, '
@@ -1555,7 +1561,7 @@ class _ReflectorDomain {
       int dynamicReflectedTypeIndex = _dynamicTypeCodeIndex(classElement.type,
           await classes, reflectedTypes, reflectedTypesOffset, typedefs);
 
-      return 'new r.GenericClassMirrorImpl(r"${classDomain._simpleName}", '
+      return 'r.GenericClassMirrorImpl(r"${classDomain._simpleName}", '
           'r"${_qualifiedName(classElement)}", $descriptor, $classIndex, '
           '${await _constConstructionCode(importCollector)}, '
           '$declarationsCode, $instanceMembersCode, $staticMembersCode, '
@@ -1599,13 +1605,13 @@ class _ReflectorDomain {
       int selfIndex = members.indexOf(accessorElement) + fields.length;
       assert(selfIndex != null);
       if (accessorElement.isGetter) {
-        return 'new r.ImplicitGetterMirrorImpl('
+        return 'r.ImplicitGetterMirrorImpl('
             '${await _constConstructionCode(importCollector)}, '
             '$variableMirrorIndex, $reflectedTypeIndex, '
             '$dynamicReflectedTypeIndex, $selfIndex)';
       } else {
         assert(accessorElement.isSetter);
-        return 'new r.ImplicitSetterMirrorImpl('
+        return 'r.ImplicitSetterMirrorImpl('
             '${await _constConstructionCode(importCollector)}, '
             '$variableMirrorIndex, $reflectedTypeIndex, '
             '$dynamicReflectedTypeIndex, $selfIndex)';
@@ -1648,7 +1654,7 @@ class _ReflectorDomain {
           ? await _extractMetadataCode(
               element, _resolver, importCollector, _generatedLibraryId)
           : null;
-      return 'new r.MethodMirrorImpl(r"${element.name}", $descriptor, '
+      return 'r.MethodMirrorImpl(r"${element.name}", $descriptor, '
           '$ownerIndex, $returnTypeIndex, $reflectedReturnTypeIndex, '
           '$dynamicReflectedReturnTypeIndex, '
           '$reflectedTypeArgumentsOfReturnType, $parameterIndicesCode, '
@@ -1693,7 +1699,7 @@ class _ReflectorDomain {
       // it is a `List<Object>`, which has no other natural encoding.
       metadataCode = null;
     }
-    return 'new r.VariableMirrorImpl(r"${element.name}", $descriptor, '
+    return 'r.VariableMirrorImpl(r"${element.name}", $descriptor, '
         '$ownerIndex, ${await _constConstructionCode(importCollector)}, '
         '$classMirrorIndex, $reflectedTypeIndex, '
         '$dynamicReflectedTypeIndex, $reflectedTypeArguments, '
@@ -1736,7 +1742,7 @@ class _ReflectorDomain {
       // it is a `List<Object>`, which has no other natural encoding.
       metadataCode = null;
     }
-    return 'new r.VariableMirrorImpl(r"${element.name}", $descriptor, '
+    return 'r.VariableMirrorImpl(r"${element.name}", $descriptor, '
         '$ownerIndex, ${await _constConstructionCode(importCollector)}, '
         '$classMirrorIndex, $reflectedTypeIndex, '
         '$dynamicReflectedTypeIndex, $reflectedTypeArguments, $metadataCode)';
@@ -2171,7 +2177,7 @@ class _ReflectorDomain {
       }));
     }
 
-    return 'new r.LibraryMirrorImpl(r"${library.name}", $uriCode, '
+    return 'r.LibraryMirrorImpl(r"${library.name}", $uriCode, '
         '${await _constConstructionCode(importCollector)}, '
         '$declarationsCode, $gettersCode, $settersCode, $metadataCode, '
         '$parameterListShapesCode)';
@@ -2250,7 +2256,7 @@ class _ReflectorDomain {
         ? "#${element.name}"
         : "null";
 
-    return 'new r.ParameterMirrorImpl(r"${element.name}", $descriptor, '
+    return 'r.ParameterMirrorImpl(r"${element.name}", $descriptor, '
         '$ownerIndex, ${await _constConstructionCode(importCollector)}, '
         '$classMirrorIndex, $reflectedTypeIndex, $dynamicReflectedTypeIndex, '
         '$reflectedTypeArguments, $metadataCode, $defaultValueCode, '
@@ -2328,8 +2334,9 @@ class _SuperclassFixedPoint extends FixedPoint<ClassElement> {
     if (!_includedByUpwardsClosure(element)) return [];
 
     InterfaceType workingSuperType = element.supertype;
-    if (workingSuperType == null)
+    if (workingSuperType == null) {
       return []; // "Superclass of [Object]", ignore.
+    }
     ClassElement workingSuperclass = workingSuperType.element;
 
     List<ClassElement> result = [];
@@ -4152,8 +4159,9 @@ initializeReflectable() {
   Future<LibraryElement> _resolvedLibraryOf(
       LibraryElement libraryElement) async {
     for (LibraryElement libraryElement2 in _libraries) {
-      if (libraryElement.identifier == libraryElement2.identifier)
+      if (libraryElement.identifier == libraryElement2.identifier) {
         return libraryElement2;
+      }
     }
     // This can occur when the library is not used.
     await _fine("Could not resolve library $libraryElement");
@@ -5045,7 +5053,7 @@ Future<String> _assetIdToUri(
           messageTarget));
       return null;
     }
-    return new Uri(
+    return Uri(
             path: path.url
                 .relative(assetId.path, from: path.url.dirname(from.path)))
         .toString();

--- a/lib/src/builder_implementation.dart
+++ b/lib/src/builder_implementation.dart
@@ -4325,7 +4325,11 @@ int _declarationDescriptor(ExecutableElement element) {
   if (element.isPrivate) result |= constants.privateAttribute;
   if (element.isStatic) result |= constants.staticAttribute;
   if (element.isSynthetic) result |= constants.syntheticAttribute;
-  if (element.isAbstract) result |= constants.abstractAttribute;
+  // TODO(eernst): Work around issue in analyzer, cf. #39051.
+  // When resolved, only the inner `if` is needed.
+  if (element is! ConstructorElement) {
+    if (element.isAbstract) result |= constants.abstractAttribute;
+  }
   if (element.enclosingElement is! ClassElement) {
     result |= constants.topLevelAttribute;
   }

--- a/lib/src/builder_implementation.dart
+++ b/lib/src/builder_implementation.dart
@@ -4059,6 +4059,8 @@ class BuilderImplementation {
 import "dart:core";
 ${imports.join('\n')}
 
+// ignore_for_file: unnecessary_const
+
 // ignore:unused_import
 import "package:reflectable/mirrors.dart" as m;
 // ignore:unused_import

--- a/lib/src/element_capability.dart
+++ b/lib/src/element_capability.dart
@@ -43,7 +43,7 @@ class InstanceInvokeCapability extends NamePatternCapability {
   const InstanceInvokeCapability(String namePattern) : super(namePattern);
 }
 
-const instanceInvokeCapability = const InstanceInvokeCapability("");
+const instanceInvokeCapability = InstanceInvokeCapability("");
 
 class InstanceInvokeMetaCapability extends MetadataQuantifiedCapability {
   const InstanceInvokeMetaCapability(ClassElement metadataType)
@@ -55,7 +55,7 @@ class StaticInvokeCapability extends NamePatternCapability
   const StaticInvokeCapability(String namePattern) : super(namePattern);
 }
 
-const staticInvokeCapability = const StaticInvokeCapability("");
+const staticInvokeCapability = StaticInvokeCapability("");
 
 class StaticInvokeMetaCapability extends MetadataQuantifiedCapability
     implements TypeCapability {
@@ -77,7 +77,7 @@ class NewInstanceCapability extends NamePatternCapability
   const NewInstanceCapability(String namePattern) : super(namePattern);
 }
 
-const newInstanceCapability = const NewInstanceCapability("");
+const newInstanceCapability = NewInstanceCapability("");
 
 class NewInstanceMetaCapability extends MetadataQuantifiedCapability
     implements TypeCapability {
@@ -97,7 +97,7 @@ class NameCapability implements TypeCapability {
 /// We do not mark it as deprecated at this time because it will be needed in
 /// order to handle usages of the deprecated `NameCapability` class or
 /// `nameCapability` value in client code.
-const nameCapability = const NameCapability();
+const nameCapability = NameCapability();
 
 /// To be eliminated when `ClassifyCapability` in 'capability.dart' is
 /// eliminated. We do not mark it as deprecated at this time because it will be
@@ -111,51 +111,51 @@ class ClassifyCapability implements TypeCapability {
 /// eliminated. We do not mark it as deprecated at this time because it will be
 /// needed in order to handle usages of the deprecated `ClassifyCapability`
 /// class or `classifyCapability` value in client code.
-const classifyCapability = const ClassifyCapability();
+const classifyCapability = ClassifyCapability();
 
 class MetadataCapability implements TypeCapability {
   const MetadataCapability();
 }
 
-const metadataCapability = const MetadataCapability();
+const metadataCapability = MetadataCapability();
 
 class TypeCapability implements ApiReflectCapability {
   const TypeCapability();
 }
 
-const typeCapability = const TypeCapability();
+const typeCapability = TypeCapability();
 
 class TypeRelationsCapability implements TypeCapability {
   const TypeRelationsCapability();
 }
 
-const typeRelationsCapability = const TypeRelationsCapability();
+const typeRelationsCapability = TypeRelationsCapability();
 
-const reflectedTypeCapability = const _ReflectedTypeCapability();
+const reflectedTypeCapability = _ReflectedTypeCapability();
 
 class LibraryCapability implements ApiReflectCapability {
   const LibraryCapability();
 }
 
-const libraryCapability = const LibraryCapability();
+const libraryCapability = LibraryCapability();
 
 class DeclarationsCapability implements TypeCapability {
   const DeclarationsCapability();
 }
 
-const declarationsCapability = const DeclarationsCapability();
+const declarationsCapability = DeclarationsCapability();
 
 class UriCapability implements LibraryCapability {
   const UriCapability();
 }
 
-const uriCapability = const UriCapability();
+const uriCapability = UriCapability();
 
 class LibraryDependenciesCapability implements LibraryCapability {
   const LibraryDependenciesCapability();
 }
 
-const libraryDependenciesCapability = const LibraryDependenciesCapability();
+const libraryDependenciesCapability = LibraryDependenciesCapability();
 
 class InvokingCapability extends NamePatternCapability
     implements
@@ -165,7 +165,7 @@ class InvokingCapability extends NamePatternCapability
   const InvokingCapability(String namePattern) : super(namePattern);
 }
 
-const invokingCapability = const InvokingCapability("");
+const invokingCapability = InvokingCapability("");
 
 class InvokingMetaCapability extends MetadataQuantifiedCapability
     implements
@@ -188,15 +188,15 @@ class TypingCapability
   const TypingCapability();
 }
 
-const typingCapability = const TypingCapability();
+const typingCapability = TypingCapability();
 
-const delegateCapability = const _DelegateCapability();
+const delegateCapability = _DelegateCapability();
 
 abstract class ReflecteeQuantifyCapability implements ReflectCapability {
   const ReflecteeQuantifyCapability();
 }
 
-const subtypeQuantifyCapability = const _SubtypeQuantifyCapability();
+const subtypeQuantifyCapability = _SubtypeQuantifyCapability();
 
 class SuperclassQuantifyCapability implements ReflecteeQuantifyCapability {
   final Element upperBound;
@@ -207,7 +207,7 @@ class SuperclassQuantifyCapability implements ReflecteeQuantifyCapability {
 }
 
 // Note that `null` represents the [ClassElement] for `Object`.
-const superclassQuantifyCapability = const SuperclassQuantifyCapability(null);
+const superclassQuantifyCapability = SuperclassQuantifyCapability(null);
 
 class TypeAnnotationQuantifyCapability implements ReflecteeQuantifyCapability {
   final bool transitive;
@@ -215,16 +215,15 @@ class TypeAnnotationQuantifyCapability implements ReflecteeQuantifyCapability {
       : transitive = transitive;
 }
 
-const typeAnnotationQuantifyCapability =
-    const TypeAnnotationQuantifyCapability();
+const typeAnnotationQuantifyCapability = TypeAnnotationQuantifyCapability();
 
 const typeAnnotationDeepQuantifyCapability =
-    const TypeAnnotationQuantifyCapability(transitive: true);
+    TypeAnnotationQuantifyCapability(transitive: true);
 
 const correspondingSetterQuantifyCapability =
-    const _CorrespondingSetterQuantifyCapability();
+    _CorrespondingSetterQuantifyCapability();
 
-const admitSubtypeCapability = const _AdmitSubtypeCapability();
+const admitSubtypeCapability = _AdmitSubtypeCapability();
 
 class ImportAttachedCapability {
   final Element reflector;

--- a/lib/src/fixed_point.dart
+++ b/lib/src/fixed_point.dart
@@ -17,7 +17,7 @@ abstract class FixedPoint<T> {
     Set<T> workingSet = initialSet;
     bool isNew(T element) => !initialSet.contains(element);
     while (workingSet.isNotEmpty) {
-      Set<T> newSet = new Set<T>();
+      Set<T> newSet = Set<T>();
       Future<void> addSuccessors(T element) async =>
           (await successors(element)).where(isNew).forEach(newSet.add);
       for (var t in workingSet) {
@@ -32,7 +32,7 @@ abstract class FixedPoint<T> {
   /// Expands the given `initialSet` a single time, adding the immediate
   /// [successors] to it. Then it returns the expanded `initialSet`.
   Future<Set<T>> singleExpand(final Set<T> initialSet) async {
-    Set<T> newSet = new Set<T>();
+    Set<T> newSet = Set<T>();
     Future<void> addSuccessors(T t) async =>
         (await successors(t)).forEach(newSet.add);
     for (var t in initialSet) {

--- a/lib/src/incompleteness.dart
+++ b/lib/src/incompleteness.dart
@@ -25,7 +25,7 @@ Null unreachableError(String message) {
   String extendedMessage =
       "*** Unexpected situation encountered!\nPlease report a bug on "
       "github.com/dart-lang/reflectable: $message.";
-  throw new UnreachableError(extendedMessage);
+  throw UnreachableError(extendedMessage);
 }
 
 /// Used to throw an [UnimplementedError]. Can be invoked with
@@ -38,5 +38,5 @@ Null unimplementedError(String message) {
       "implemented: $message.\n"
       "If you wish to ensure that it is prioritized, please report it "
       "on github.com/dart-lang/reflectable.";
-  throw new UnimplementedError(extendedMessage);
+  throw UnimplementedError(extendedMessage);
 }

--- a/lib/src/reflectable_builder_based.dart
+++ b/lib/src/reflectable_builder_based.dart
@@ -141,7 +141,7 @@ class ReflectorData {
           }
         }
 
-        _typeToClassMirrorCache = new Map<Type, ClassMirror>.fromIterables(
+        _typeToClassMirrorCache = Map<Type, ClassMirror>.fromIterables(
             types.sublist(0, supportedClassCount), classMirrors());
       }
     }
@@ -172,12 +172,11 @@ const String pleaseInitializeMessage = "Reflectable has not been initialized.\n"
 /// This mapping contains the mirror-data for each reflector.
 /// It will be initialized in the generated code.
 Map<Reflectable, ReflectorData> data =
-    throw new StateError(pleaseInitializeMessage);
+    throw StateError(pleaseInitializeMessage);
 
 /// This mapping translates symbols to strings for the covered members.
 /// It will be initialized in the generated code.
-Map<Symbol, String> memberSymbolMap =
-    throw new StateError(pleaseInitializeMessage);
+Map<Symbol, String> memberSymbolMap = throw StateError(pleaseInitializeMessage);
 
 abstract class _DataCaching {
   // TODO(eernst) clarify: When we have some substantial pieces of code using
@@ -214,7 +213,7 @@ class _InstanceMirrorImpl extends _DataCaching implements InstanceMirror {
       // completely unsupported class, so we still insist that the runtime
       // type of the reflectee is known.
       if (!_data.types.contains(reflectee.runtimeType)) {
-        throw new NoSuchCapabilityError(
+        throw NoSuchCapabilityError(
             "Reflecting on un-marked type '${reflectee.runtimeType}'");
       }
     }
@@ -226,7 +225,7 @@ class _InstanceMirrorImpl extends _DataCaching implements InstanceMirror {
 
   ClassMirror get type {
     if (!_supportsType) {
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Attempt to get `type` without `TypeCapability`.");
     }
     return _type;
@@ -295,7 +294,7 @@ class _InstanceMirrorImpl extends _DataCaching implements InstanceMirror {
     }
 
     if (memberSymbolMap == null) {
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Attempt to `delegate` without `delegateCapability");
     }
     String memberName = memberSymbolMap[invocation.memberName];
@@ -383,7 +382,7 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
   List<ClassMirror> get superinterfaces {
     if (_superinterfaceIndices.length == 1 &&
         _superinterfaceIndices[0] == NO_CAPABILITY_INDEX) {
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Requesting `superinterfaces` of `$qualifiedName` "
           "without `typeRelationsCapability`");
     }
@@ -393,7 +392,7 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
         // containing just the single element [NO_CAPABILITY_INDEX] then
         // we do have the `typeRelationsCapability`, but we may still
         // encounter a single unsupported superinterface.
-        throw new NoSuchCapabilityError(
+        throw NoSuchCapabilityError(
             "Requesting a superinterface of '$qualifiedName' "
             "without capability");
       }
@@ -471,15 +470,14 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
         // need not have stellar performance, it is almost always a bug to do
         // that.
         if (declarationIndex == NO_CAPABILITY_INDEX) {
-          throw new NoSuchCapabilityError(
+          throw NoSuchCapabilityError(
               "Requesting declarations of '$qualifiedName' without capability");
         }
         DeclarationMirror declarationMirror =
             _data.memberMirrors[declarationIndex];
         result[declarationMirror.simpleName] = declarationMirror;
       }
-      _declarations =
-          new UnmodifiableMapView<String, DeclarationMirror>(result);
+      _declarations = UnmodifiableMapView<String, DeclarationMirror>(result);
     }
     return _declarations;
   }
@@ -489,7 +487,7 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
   Map<String, MethodMirror> get instanceMembers {
     if (_instanceMembers == null) {
       if (_instanceMemberIndices == null) {
-        throw new NoSuchCapabilityError(
+        throw NoSuchCapabilityError(
             "Requesting instanceMembers without `declarationsCapability`.");
       }
       Map<String, MethodMirror> result = <String, MethodMirror>{};
@@ -499,7 +497,7 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
         assert(declarationMirror is MethodMirror);
         result[declarationMirror.simpleName] = declarationMirror;
       }
-      _instanceMembers = new UnmodifiableMapView<String, MethodMirror>(result);
+      _instanceMembers = UnmodifiableMapView<String, MethodMirror>(result);
     }
     return _instanceMembers;
   }
@@ -509,7 +507,7 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
   Map<String, MethodMirror> get staticMembers {
     if (_staticMembers == null) {
       if (_staticMemberIndices == null) {
-        throw new NoSuchCapabilityError(
+        throw NoSuchCapabilityError(
             "Requesting instanceMembers without `declarationsCapability`.");
       }
       Map<String, MethodMirror> result = <String, MethodMirror>{};
@@ -519,7 +517,7 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
         assert(declarationMirror is MethodMirror);
         result[declarationMirror.simpleName] = declarationMirror;
       }
-      _staticMembers = new UnmodifiableMapView<String, MethodMirror>(result);
+      _staticMembers = UnmodifiableMapView<String, MethodMirror>(result);
     }
     return _staticMembers;
   }
@@ -527,11 +525,11 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
   ClassMirror get mixin {
     if (_mixinIndex == NO_CAPABILITY_INDEX) {
       if (!_supportsTypeRelations(_reflector)) {
-        throw new NoSuchCapabilityError(
+        throw NoSuchCapabilityError(
             "Attempt to get `mixin` for `$qualifiedName` "
             "without `typeRelationsCapability`");
       }
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Attempt to get mixin from '$simpleName' without capability");
     }
     return _data.typeMirrors[_mixinIndex];
@@ -685,14 +683,14 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
   bool get isTopLevel => true;
 
   @override
-  SourceLocation get location => throw new UnsupportedError("location");
+  SourceLocation get location => throw UnsupportedError("location");
 
   @override
   List<Object> get metadata {
     if (_metadata == null) {
       String description =
           hasReflectedType ? reflectedType.toString() : qualifiedName;
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Requesting metadata of '$description' without capability");
     }
     return _metadata;
@@ -718,11 +716,11 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
       // to superinterfaces, that is, it is not necessary (nor useful) to check
       // for access to superinterfaces here.
       if (!_supportsTypeRelations(_reflector)) {
-        throw new NoSuchCapabilityError(
+        throw NoSuchCapabilityError(
             "Attempt to evaluate `isAssignableTo` for `$qualifiedName` "
             "without `typeRelationsCapability`");
       }
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Attempt to evaluate `isAssignableTo` for `$qualifiedName` "
           "without capability.");
     }
@@ -741,11 +739,11 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
       // to superinterfaces, that is, it is not necessary (nor useful) to check
       // for access to superinterfaces here.
       if (!_supportsTypeRelations(_reflector)) {
-        throw new NoSuchCapabilityError(
+        throw NoSuchCapabilityError(
             "Attempt to evaluate `isSubtypeOf` for `$qualifiedName` "
             "without `typeRelationsCapability`");
       }
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Attempt to evaluate `isSubtypeOf` for `$qualifiedName` "
           "without capability.");
     }
@@ -779,11 +777,11 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
       // to superinterfaces, that is, it is not necessary (nor useful) to check
       // for access to superinterfaces here.
       if (!_supportsTypeRelations(_reflector)) {
-        throw new NoSuchCapabilityError(
+        throw NoSuchCapabilityError(
             "Attempt to evaluate `isSubclassOf` for `$qualifiedName` "
             "without `typeRelationsCapability`");
       }
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Attempt to evaluate `isSubclassOf` for $qualifiedName "
           "without capability.");
     }
@@ -807,11 +805,11 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
   DeclarationMirror get owner {
     if (_ownerIndex == NO_CAPABILITY_INDEX) {
       if (!_supportsTypeRelations(_reflector)) {
-        throw new NoSuchCapabilityError(
+        throw NoSuchCapabilityError(
             "Attempt to get `owner` of `$qualifiedName` "
             "without `typeRelationsCapability`");
       }
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Trying to get owner of class '$qualifiedName' "
           "without 'libraryCapability'");
     }
@@ -821,11 +819,11 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
   ClassMirrorBase get superclass {
     if (_superclassIndex == NO_CAPABILITY_INDEX) {
       if (!_supportsTypeRelations(_reflector)) {
-        throw new NoSuchCapabilityError(
+        throw NoSuchCapabilityError(
             "Attempt to get `superclass` of `$qualifiedName` "
             "without `typeRelationsCapability`");
       }
-      throw new NoSuchCapabilityError("Requesting mirror on un-marked class, "
+      throw NoSuchCapabilityError("Requesting mirror on un-marked class, "
           "`superclass` of `$qualifiedName`");
     }
     if (_superclassIndex == null) return null; // Superclass of [Object].
@@ -884,7 +882,7 @@ class NonGenericClassMirrorImpl extends ClassMirrorBase {
   @override
   List<TypeMirror> get typeArguments {
     if (!_supportsTypeRelations(_reflector)) {
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Attempt to get `typeArguments` for `$qualifiedName` "
           "without `typeRelationsCapability`");
     }
@@ -895,7 +893,7 @@ class NonGenericClassMirrorImpl extends ClassMirrorBase {
   List<Type> get reflectedTypeArguments {
     if (!_supportsTypeRelations(_reflector) ||
         !_supportsReflectedType(_reflector)) {
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Attempt to get `typeArguments` for `$qualifiedName` "
           "without `typeRelationsCapability` or `reflectedTypeCapability`");
     }
@@ -905,7 +903,7 @@ class NonGenericClassMirrorImpl extends ClassMirrorBase {
   @override
   List<TypeVariableMirror> get typeVariables {
     if (!_supportsTypeRelations(_reflector)) {
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Attempt to evaluate `typeVariables` for `$qualifiedName` "
           "without `typeRelationsCapability`");
     }
@@ -918,7 +916,7 @@ class NonGenericClassMirrorImpl extends ClassMirrorBase {
   @override
   TypeMirror get originalDeclaration {
     if (!_supportsTypeRelations(_reflector)) {
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Attempt to get `originalDeclaration` for `$qualifiedName` "
           "without `typeRelationsCapability`");
     }
@@ -1006,7 +1004,7 @@ class GenericClassMirrorImpl extends ClassMirrorBase {
   @override
   List<TypeMirror> get typeArguments {
     if (!_supportsTypeRelations(_reflector)) {
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Attempt to get `typeArguments` for `$qualifiedName` "
           "without `typeRelationsCapability`");
     }
@@ -1020,7 +1018,7 @@ class GenericClassMirrorImpl extends ClassMirrorBase {
   List<Type> get reflectedTypeArguments {
     if (!_supportsTypeRelations(_reflector) ||
         !_supportsReflectedType(_reflector)) {
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Attempt to get `reflectedTypeArguments` for `$qualifiedName` "
           "without `typeRelationsCapability` or `reflectedTypeCapability`");
     }
@@ -1038,11 +1036,11 @@ class GenericClassMirrorImpl extends ClassMirrorBase {
   List<TypeVariableMirror> get typeVariables {
     if (_typeVariableIndices == null) {
       if (!_supportsTypeRelations(_reflector)) {
-        throw new NoSuchCapabilityError(
+        throw NoSuchCapabilityError(
             "Attempt to evaluate `typeVariables` for `$qualifiedName` "
             "without `typeRelationsCapability`");
       }
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Requesting type variables of `$qualifiedName` without capability");
     }
     List<TypeVariableMirror> result = <TypeVariableMirror>[];
@@ -1052,7 +1050,7 @@ class GenericClassMirrorImpl extends ClassMirrorBase {
       assert(typeVariableMirror is TypeVariableMirror);
       result.add(typeVariableMirror);
     }
-    return new List<TypeVariableMirror>.unmodifiable(result);
+    return List<TypeVariableMirror>.unmodifiable(result);
   }
 
   @override
@@ -1061,7 +1059,7 @@ class GenericClassMirrorImpl extends ClassMirrorBase {
   @override
   TypeMirror get originalDeclaration {
     if (!_supportsTypeRelations(_reflector)) {
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Attempt to get `originalDeclaration` for `$qualifiedName` "
           "without `typeRelationsCapability`");
     }
@@ -1073,7 +1071,7 @@ class GenericClassMirrorImpl extends ClassMirrorBase {
 
   @override
   Type get reflectedType {
-    throw new UnsupportedError("Attempt to obtain `reflectedType` "
+    throw UnsupportedError("Attempt to obtain `reflectedType` "
         "from generic class '$qualifiedName'.");
   }
 
@@ -1084,11 +1082,11 @@ class GenericClassMirrorImpl extends ClassMirrorBase {
   Type get dynamicReflectedType {
     if (_dynamicReflectedTypeIndex == NO_CAPABILITY_INDEX) {
       if (!_supportsReflectedType(_reflector)) {
-        throw new NoSuchCapabilityError(
+        throw NoSuchCapabilityError(
             "Attempt to evaluate `dynamicReflectedType` for `$qualifiedName` "
             "without `reflectedTypeCapability`");
       }
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Attempt to get `dynamicReflectedType` for `$qualifiedName` "
           "without capability");
     }
@@ -1153,7 +1151,7 @@ class InstantiatedGenericClassMirrorImpl extends ClassMirrorBase {
   @override
   List<TypeMirror> get typeArguments {
     if (!_supportsTypeRelations(_reflector)) {
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Attempt to get `typeArguments` for `$qualifiedName` "
           "without `typeRelationsCapability`");
     }
@@ -1166,7 +1164,7 @@ class InstantiatedGenericClassMirrorImpl extends ClassMirrorBase {
   List<Type> get reflectedTypeArguments {
     if (!_supportsTypeRelations(_reflector) ||
         !_supportsReflectedType(_reflector)) {
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Attempt to get `reflectedTypeArguments` for `$qualifiedName` "
           "without `typeRelationsCapability` or `reflectedTypeCapability`");
     }
@@ -1188,7 +1186,7 @@ class InstantiatedGenericClassMirrorImpl extends ClassMirrorBase {
   @override
   TypeMirror get originalDeclaration {
     if (!_supportsTypeRelations(_reflector)) {
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Attempt to get `originalDeclaration` for `$qualifiedName` "
           "without `typeRelationsCapability`");
     }
@@ -1203,7 +1201,7 @@ class InstantiatedGenericClassMirrorImpl extends ClassMirrorBase {
     if (_reflectedType != null) {
       return _reflectedType;
     }
-    throw new UnsupportedError("Cannot provide `reflectedType` of "
+    throw UnsupportedError("Cannot provide `reflectedType` of "
         "instance of generic type '$simpleName'.");
   }
 
@@ -1264,7 +1262,7 @@ InstantiatedGenericClassMirrorImpl _createInstantiatedGenericClass(
   // TODO(eernst) implement: Pass a representation of type arguments to this
   // method, and create an instantiated generic class which includes that
   // information.
-  return new InstantiatedGenericClassMirrorImpl(
+  return InstantiatedGenericClassMirrorImpl(
       genericClassMirror.simpleName,
       genericClassMirror.qualifiedName,
       genericClassMirror._descriptor,
@@ -1320,9 +1318,9 @@ class TypeVariableMirrorImpl extends _DataCaching
 
   @override
   TypeMirror get upperBound {
-    if (_upperBoundIndex == null) return new DynamicMirrorImpl();
+    if (_upperBoundIndex == null) return DynamicMirrorImpl();
     if (_upperBoundIndex == NO_CAPABILITY_INDEX) {
-      throw new NoSuchCapabilityError("Attempt to get `upperBound` from type "
+      throw NoSuchCapabilityError("Attempt to get `upperBound` from type "
           "variable mirror without capability.");
     }
     return _data.typeMirrors[_upperBoundIndex];
@@ -1331,7 +1329,7 @@ class TypeVariableMirrorImpl extends _DataCaching
   @override
   bool isAssignableTo(TypeMirror other) {
     if (!_supportsTypeRelations(_reflector)) {
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Attempt to get `isAssignableTo` for `$qualifiedName` "
           "without `typeRelationsCapability`");
     }
@@ -1341,7 +1339,7 @@ class TypeVariableMirrorImpl extends _DataCaching
   @override
   bool isSubtypeOf(TypeMirror other) {
     if (!_supportsTypeRelations(_reflector)) {
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Attempt to get `isSubtypeOf` for `$qualifiedName` "
           "without `typeRelationsCapability`");
     }
@@ -1351,7 +1349,7 @@ class TypeVariableMirrorImpl extends _DataCaching
   @override
   TypeMirror get originalDeclaration {
     if (!_supportsTypeRelations(_reflector)) {
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Attempt to get `originalDeclaration` for `$qualifiedName` "
           "without `typeRelationsCapability`");
     }
@@ -1364,7 +1362,7 @@ class TypeVariableMirrorImpl extends _DataCaching
   @override
   List<TypeMirror> get typeArguments {
     if (!_supportsTypeRelations(_reflector)) {
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Attempt to get `typeArguments` for `$qualifiedName` "
           "without `typeRelationsCapability`");
     }
@@ -1375,7 +1373,7 @@ class TypeVariableMirrorImpl extends _DataCaching
   List<Type> get reflectedTypeArguments {
     if (!_supportsTypeRelations(_reflector) ||
         !_supportsReflectedType(_reflector)) {
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Attempt to get `reflectedTypeArguments` for `$qualifiedName` "
           "without `typeRelationsCapability` or `reflectedTypeCapability`");
     }
@@ -1385,7 +1383,7 @@ class TypeVariableMirrorImpl extends _DataCaching
   @override
   List<TypeVariableMirror> get typeVariables {
     if (!_supportsTypeRelations(_reflector)) {
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Attempt to evaluate `typeVariables` for `$qualifiedName` "
           "without `typeRelationsCapability`");
     }
@@ -1394,7 +1392,7 @@ class TypeVariableMirrorImpl extends _DataCaching
 
   @override
   Type get reflectedType {
-    throw new UnsupportedError("Attempt to get `reflectedType` from type "
+    throw UnsupportedError("Attempt to get `reflectedType` from type "
         "variable $simpleName");
   }
 
@@ -1404,14 +1402,14 @@ class TypeVariableMirrorImpl extends _DataCaching
   @override
   List<Object> get metadata {
     if (_metadata == null) {
-      throw new NoSuchCapabilityError("Attempt to get `metadata` from type "
+      throw NoSuchCapabilityError("Attempt to get `metadata` from type "
           "variable $simpleName without capability");
     }
     return <Object>[];
   }
 
   @override
-  SourceLocation get location => throw new UnsupportedError("location");
+  SourceLocation get location => throw UnsupportedError("location");
 
   @override
   bool get isTopLevel => false;
@@ -1422,7 +1420,7 @@ class TypeVariableMirrorImpl extends _DataCaching
   @override
   DeclarationMirror get owner {
     if (_ownerIndex == NO_CAPABILITY_INDEX) {
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Trying to get owner of type parameter '$qualifiedName' "
           "without capability");
     }
@@ -1478,7 +1476,7 @@ class LibraryMirrorImpl extends _DataCaching implements LibraryMirror {
         // need not have stellar performance, it is almost always a bug to do
         // that.
         if (declarationIndex == NO_CAPABILITY_INDEX) {
-          throw new NoSuchCapabilityError(
+          throw NoSuchCapabilityError(
               "Requesting declarations of '$qualifiedName' without capability");
         }
         DeclarationMirror declarationMirror =
@@ -1490,8 +1488,7 @@ class LibraryMirrorImpl extends _DataCaching implements LibraryMirror {
           result[typeMirror.simpleName] = typeMirror;
         }
       });
-      _declarations =
-          new UnmodifiableMapView<String, DeclarationMirror>(result);
+      _declarations = UnmodifiableMapView<String, DeclarationMirror>(result);
     }
     return _declarations;
   }
@@ -1603,14 +1600,14 @@ class LibraryMirrorImpl extends _DataCaching implements LibraryMirror {
   bool get isTopLevel => false;
 
   @override
-  SourceLocation get location => throw new UnsupportedError("location");
+  SourceLocation get location => throw UnsupportedError("location");
 
   final List<Object> _metadata;
 
   @override
   List<Object> get metadata {
     if (_metadata == null) {
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Requesting metadata of library '$simpleName' without capability");
     }
     return _metadata;
@@ -1697,7 +1694,7 @@ class MethodMirrorImpl extends _DataCaching implements MethodMirror {
 
   DeclarationMirror get owner {
     if (_ownerIndex == NO_CAPABILITY_INDEX) {
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Trying to get owner of method '$qualifiedName' "
           "without 'LibraryCapability'");
     }
@@ -1767,12 +1764,12 @@ class MethodMirrorImpl extends _DataCaching implements MethodMirror {
       (_descriptor & constants.genericReturnTypeAttribute != 0);
 
   @override
-  SourceLocation get location => throw new UnsupportedError("location");
+  SourceLocation get location => throw UnsupportedError("location");
 
   @override
   List<Object> get metadata {
     if (_metadata == null) {
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Requesting metadata of method '$simpleName' without capability");
     }
     return _metadata;
@@ -1781,7 +1778,7 @@ class MethodMirrorImpl extends _DataCaching implements MethodMirror {
   @override
   List<ParameterMirror> get parameters {
     if (!_supportsDeclarations(_reflector)) {
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Attempt to get `parameters` without `DeclarationsCapability`");
     }
     return _parameterIndices
@@ -1795,11 +1792,11 @@ class MethodMirrorImpl extends _DataCaching implements MethodMirror {
   @override
   TypeMirror get returnType {
     if (_returnTypeIndex == NO_CAPABILITY_INDEX) {
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Requesting returnType of method '$simpleName' without capability");
     }
-    if (_hasDynamicReturnType) return new DynamicMirrorImpl();
-    if (_hasVoidReturnType) return new VoidMirrorImpl();
+    if (_hasDynamicReturnType) return DynamicMirrorImpl();
+    if (_hasVoidReturnType) return VoidMirrorImpl();
     if (_hasClassReturnType) {
       return _hasGenericReturnType
           ? _createInstantiatedGenericClass(_data.typeMirrors[_returnTypeIndex],
@@ -1816,8 +1813,7 @@ class MethodMirrorImpl extends _DataCaching implements MethodMirror {
   @override
   Type get reflectedReturnType {
     if (_reflectedReturnTypeIndex == NO_CAPABILITY_INDEX) {
-      throw new NoSuchCapabilityError(
-          "Requesting reflectedReturnType of method "
+      throw NoSuchCapabilityError("Requesting reflectedReturnType of method "
           "'$simpleName' without capability");
     }
     return _data.types[_reflectedReturnTypeIndex];
@@ -1846,7 +1842,7 @@ class MethodMirrorImpl extends _DataCaching implements MethodMirror {
   void _setupParameterListInfo() {
     _numberOfPositionalParameters = 0;
     _numberOfOptionalPositionalParameters = 0;
-    _namesOfNamedParameters = new Set<Symbol>();
+    _namesOfNamedParameters = Set<Symbol>();
     for (ParameterMirrorImpl parameterMirror in parameters) {
       if (parameterMirror.isNamed) {
         _namesOfNamedParameters.add(parameterMirror._nameSymbol);
@@ -1975,7 +1971,7 @@ abstract class ImplicitAccessorMirrorImpl extends _DataCaching
   bool get isTopLevel => false;
 
   @override
-  SourceLocation get location => throw new UnsupportedError("location");
+  SourceLocation get location => throw UnsupportedError("location");
 
   @override
   List<Object> get metadata => <Object>[];
@@ -2015,7 +2011,7 @@ class ImplicitGetterMirrorImpl extends ImplicitAccessorMirrorImpl {
   @override
   List<ParameterMirror> get parameters {
     if (!_supportsDeclarations(_reflector)) {
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Attempt to get `parameters` without `DeclarationsCapability`");
     }
     return <ParameterMirror>[];
@@ -2049,19 +2045,21 @@ class ImplicitSetterMirrorImpl extends ImplicitAccessorMirrorImpl {
     if (_variableMirror.isPrivate) descriptor |= constants.privateAttribute;
     descriptor |= constants.syntheticAttribute;
     if (_variableMirror._isDynamic) descriptor |= constants.dynamicAttribute;
-    if (_variableMirror._isClassType)
+    if (_variableMirror._isClassType) {
       descriptor |= constants.classTypeAttribute;
+    }
+
     return descriptor;
   }
 
   @override
   List<ParameterMirror> get parameters {
     if (!_supportsDeclarations(_reflector)) {
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Attempt to get `parameters` without `DeclarationsCapability`");
     }
     return <ParameterMirror>[
-      new ParameterMirrorImpl(
+      ParameterMirrorImpl(
           _variableMirror.simpleName,
           _parameterDescriptor,
           _selfIndex,
@@ -2128,12 +2126,12 @@ abstract class VariableMirrorBase extends _DataCaching
       (_descriptor & constants.genericTypeAttribute != 0);
 
   @override
-  SourceLocation get location => throw new UnsupportedError("location");
+  SourceLocation get location => throw UnsupportedError("location");
 
   @override
   List<Object> get metadata {
     if (_metadata == null) {
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Requesting metadata of field '$simpleName' without capability");
     }
     return _metadata;
@@ -2149,13 +2147,13 @@ abstract class VariableMirrorBase extends _DataCaching
   TypeMirror get type {
     if (_classMirrorIndex == NO_CAPABILITY_INDEX) {
       if (!_supportsType(_reflector)) {
-        throw new NoSuchCapabilityError(
+        throw NoSuchCapabilityError(
             "Attempt to get `type` without `TypeCapability`");
       }
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Attempt to get class mirror for un-marked class (type of '$_name')");
     }
-    if (_isDynamic) return new DynamicMirrorImpl();
+    if (_isDynamic) return DynamicMirrorImpl();
     if (_isClassType) {
       return _isGenericType
           ? _createInstantiatedGenericClass(
@@ -2175,10 +2173,10 @@ abstract class VariableMirrorBase extends _DataCaching
   Type get reflectedType {
     if (_reflectedTypeIndex == NO_CAPABILITY_INDEX) {
       if (!_supportsReflectedType(_reflector)) {
-        throw new NoSuchCapabilityError(
+        throw NoSuchCapabilityError(
             "Attempt to get `reflectedType` without `reflectedTypeCapability`");
       }
-      throw new UnsupportedError(
+      throw UnsupportedError(
           "Attempt to get reflectedType without capability (of '$_name')");
     }
     if (_isDynamic) return dynamic;
@@ -2208,7 +2206,7 @@ class VariableMirrorImpl extends VariableMirrorBase {
   @override
   DeclarationMirror get owner {
     if (_ownerIndex == NO_CAPABILITY_INDEX) {
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Trying to get owner of variable '$qualifiedName' "
           "without capability");
     }
@@ -2272,7 +2270,7 @@ class ParameterMirrorImpl extends VariableMirrorBase
   @override
   bool get hasDefaultValue {
     if (!_supportsDeclarations(_reflector)) {
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Attempt to get `hasDefaultValue` without `DeclarationsCapability`");
     }
     return (_descriptor & constants.hasDefaultValueAttribute != 0);
@@ -2281,7 +2279,7 @@ class ParameterMirrorImpl extends VariableMirrorBase
   @override
   Object get defaultValue {
     if (!_supportsDeclarations(_reflector)) {
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Attempt to get `defaultValue` without `DeclarationsCapability`");
     }
     return _defaultValue;
@@ -2366,7 +2364,7 @@ class DynamicMirrorImpl implements TypeMirror {
   TypeMirror get originalDeclaration => this;
 
   @override
-  SourceLocation get location => throw new UnsupportedError("location");
+  SourceLocation get location => throw UnsupportedError("location");
 
   // TODO(eernst) implement: We ought to check for the capability, which
   // means that we should have a `_reflector`, and then we should throw a
@@ -2411,7 +2409,7 @@ class VoidMirrorImpl implements TypeMirror {
 
   @override
   Type get reflectedType =>
-      throw new UnsupportedError("Attempt to get the reflected type of `void`");
+      throw UnsupportedError("Attempt to get the reflected type of `void`");
 
   @override
   String get simpleName => "void";
@@ -2431,7 +2429,7 @@ class VoidMirrorImpl implements TypeMirror {
   TypeMirror get originalDeclaration => this;
 
   @override
-  SourceLocation get location => throw new UnsupportedError("location");
+  SourceLocation get location => throw UnsupportedError("location");
 
   // TODO(eernst) implement: We ought to check for the capability, which
   // means that we should have a `supportsTypeRelations` bool, and then we
@@ -2489,7 +2487,7 @@ abstract class ReflectableImpl extends ReflectableBase
 
   @override
   InstanceMirror reflect(Object reflectee) {
-    return new _InstanceMirrorImpl(reflectee, this);
+    return _InstanceMirrorImpl(reflectee, this);
   }
 
   bool get _hasTypeCapability {
@@ -2506,7 +2504,7 @@ abstract class ReflectableImpl extends ReflectableBase
   TypeMirror reflectType(Type type) {
     ClassMirror result = data[this].classMirrorForType(type);
     if (result == null || !_hasTypeCapability) {
-      throw new NoSuchCapabilityError(
+      throw NoSuchCapabilityError(
           "Reflecting on type '$type' without capability");
     }
     return result;
@@ -2516,7 +2514,7 @@ abstract class ReflectableImpl extends ReflectableBase
   LibraryMirror findLibrary(String libraryName) {
     ReflectorData reflectorData = data[this];
     if (reflectorData.libraryMirrors == null) {
-      throw new NoSuchCapabilityError("Using 'findLibrary' without capability. "
+      throw NoSuchCapabilityError("Using 'findLibrary' without capability. "
           "Try adding `libraryCapability`.");
     }
     // The specification says that an exception shall be thrown if there
@@ -2531,11 +2529,11 @@ abstract class ReflectableImpl extends ReflectableBase
     }
     switch (matchCount) {
       case 0:
-        throw new ArgumentError("No such library: $libraryName");
+        throw ArgumentError("No such library: $libraryName");
       case 1:
         return matchingLibrary;
       default:
-        throw new ArgumentError("Ambiguous library name: $libraryName");
+        throw ArgumentError("Ambiguous library name: $libraryName");
     }
   }
 
@@ -2543,21 +2541,20 @@ abstract class ReflectableImpl extends ReflectableBase
   Map<Uri, LibraryMirror> get libraries {
     ReflectorData reflectorData = data[this];
     if (reflectorData.libraryMirrors == null) {
-      throw new NoSuchCapabilityError("Using 'libraries' without capability. "
+      throw NoSuchCapabilityError("Using 'libraries' without capability. "
           "Try adding `libraryCapability`.");
     }
     Map<Uri, LibraryMirror> result = <Uri, LibraryMirror>{};
     for (LibraryMirror library in reflectorData.libraryMirrors) {
       result[library.uri] = library;
     }
-    return new UnmodifiableMapView(result);
+    return UnmodifiableMapView(result);
   }
 
   @override
   Iterable<ClassMirror> get annotatedClasses {
-    return new List<ClassMirror>.unmodifiable(data[this]
-        .typeMirrors
-        .where((TypeMirror typeMirror) => typeMirror is ClassMirror));
+    return List<ClassMirror>.unmodifiable(
+        data[this].typeMirrors.whereType<ClassMirror>());
   }
 }
 

--- a/lib/src/reflectable_errors.dart
+++ b/lib/src/reflectable_errors.dart
@@ -50,11 +50,11 @@ const String IS_ENUM = "Encountered a reflector class which is an enum.";
 /// Finds any template holes of the form {name} in [template] and replaces them
 /// with the corresponding value in [replacements].
 String applyTemplate(String template, Map<String, String> replacements) {
-  return template.replaceAllMapped(new RegExp(r"{(.*?)}"), (Match match) {
+  return template.replaceAllMapped(RegExp(r"{(.*?)}"), (Match match) {
     String index = match.group(1);
     String replacement = replacements[index];
     if (replacement == null) {
-      throw new ArgumentError("Missing template replacement for $index");
+      throw ArgumentError("Missing template replacement for $index");
     }
     return replacements[index];
   });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,20 +8,20 @@ homepage: https://www.github.com/dart-lang/reflectable
 environment:
   sdk: '>=2.3.0 <3.0.0'
 dependencies:
-  analyzer: '>=0.36.0 <0.38.0'
-  build: ^1.1.0
-  build_resolvers: ^1.0.0
+  analyzer: '>=0.36.0 <0.39.0'
+  build: ^1.2.0
+  build_resolvers: ^1.2.0
   build_config: ^0.4.0
-  build_runner: ^1.6.0
-  build_runner_core: ^3.0.0
-  dart_style: ^1.2.0
-  glob: ^1.1.0
+  build_runner: ^1.7.0
+  build_runner_core: ^4.1.0
+  dart_style: ^1.3.0
+  glob: ^1.2.0
   logging: ^0.11.0
-  package_config: ^1.0.0
-  package_resolver: ^1.0.0
+  package_config: ^1.1.0
+  package_resolver: any # ^1.0.0
   path: ^1.6.0
   source_span: ^1.5.0
 dev_dependencies:
   build_test: ^0.10.0
   pedantic: ^1.8.0
-  test: ^1.5.0
+  test: ^1.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   package_config: ^1.0.0
   package_resolver: ^1.0.0
   path: ^1.6.0
+  pedantic: ^1.8.0
   source_span: ^1.5.0
 dev_dependencies:
   build_test: ^0.10.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,8 +20,8 @@ dependencies:
   package_config: ^1.0.0
   package_resolver: ^1.0.0
   path: ^1.6.0
-  pedantic: ^1.8.0
   source_span: ^1.5.0
 dev_dependencies:
   build_test: ^0.10.0
+  pedantic: ^1.8.0
   test: ^1.5.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: reflectable
-version: 2.1.0
+version: 2.2.0
 description: >
   Reflection support based on code generation, using 'capabilities' to
   specify which operations to support, on which objects.


### PR DESCRIPTION
Just a small cleanup from enabling pedantic checks: It mostly removes unnecessary `new` and `const` keywords from the code.