### PR TITLE
Fix linter issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2.2.1
+
+* Update reflectable to enable the use of analyzer version 0.39.*. Adjust
+  the implementation to satisfy many new lint requirements, e.g., that
+  string literals use single quotes, sets are created using literals, some
+  local variables have no type annotation, overriding declarations have
+  `@override`, etc. Also fix a bug concerned with the ordering of named
+  parameters in a constructor declaration.
+
 ## 2.2.0
 
 * Adjust implementation to satisfy 'pedantic' lints. The generated code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,10 @@
 ## 2.2.1
 
-* Update reflectable to enable the use of analyzer version 0.39.*. Adjust
-  the implementation to satisfy many new lint requirements, e.g., that
-  string literals use single quotes, sets are created using literals, some
-  local variables have no type annotation, overriding declarations have
-  `@override`, etc. Also fix a bug concerned with the ordering of named
-  parameters in a constructor declaration.
+* Fix a bug concerned with the ordering of named parameters in a constructor
+  declaration.
+* Update reflectable to use package analyzer version `<0.40.0`.
+* Ensure that generated code is lint free with package pedantic 1.9.0.
+* Make reflectable itself lint free with package pedantic 1.9.0.
 
 ## 2.2.0
 

--- a/lib/capability.dart
+++ b/lib/capability.dart
@@ -483,18 +483,31 @@ class _NoSuchCapabilityErrorImpl extends Error
 
   _NoSuchCapabilityErrorImpl(String message) : _message = message;
 
+  @override
   toString() => _message;
 }
 
 enum StringInvocationKind { method, getter, setter, constructor }
 
 class _StringInvocation extends StringInvocation {
-  final String memberName;
-  final List positionalArguments;
-  final Map<Symbol, dynamic> namedArguments;
   final StringInvocationKind kind;
+
+  @override
+  final String memberName;
+
+  @override
+  final List positionalArguments;
+
+  @override
+  final Map<Symbol, dynamic> namedArguments;
+
+  @override
   bool isMethod;
+
+  @override
   bool isGetter;
+
+  @override
   bool isSetter;
 
   _StringInvocation(this.memberName, this.positionalArguments,
@@ -523,6 +536,7 @@ class ReflectableNoSuchMethodError extends Error
   get invocation =>
       _StringInvocation(memberName, positionalArguments, namedArguments, kind);
 
+  @override
   toString() {
     String kindName;
     switch (kind) {

--- a/lib/capability.dart
+++ b/lib/capability.dart
@@ -25,9 +25,9 @@
 /// and matching all members with a metadata annotation of that type or a
 /// subtype thereof.
 ///
-/// For example `InstanceInvokeCapability(r"^foo")` will cover all instance
+/// For example `InstanceInvokeCapability(r'^foo')` will cover all instance
 /// members of annotated classes that start with
-/// "foo". `InstanceInvokeMetaCapability(Deprecated)` would cover all instance
+/// 'foo'. `InstanceInvokeMetaCapability(Deprecated)` would cover all instance
 /// members that are marked as `Deprecated`.
 ///
 /// Hint: It is important to realize that the amount of generated code might not
@@ -93,9 +93,9 @@ class InstanceInvokeCapability extends NamePatternCapability {
   const InstanceInvokeCapability(String namePattern) : super(namePattern);
 }
 
-/// Short hand for `InstanceInvokeCapability("")`, meaning the capability to
+/// Short hand for `InstanceInvokeCapability('')`, meaning the capability to
 /// reflect over all instance members.
-const instanceInvokeCapability = InstanceInvokeCapability("");
+const instanceInvokeCapability = InstanceInvokeCapability('');
 
 /// Gives support for reflective invocation of instance members (methods,
 /// getters, and setters) annotated with instances of [metadataType] or a
@@ -112,9 +112,9 @@ class StaticInvokeCapability extends NamePatternCapability
   const StaticInvokeCapability(String namePattern) : super(namePattern);
 }
 
-/// Short hand for `StaticInvokeCapability("")`, meaning the capability to
+/// Short hand for `StaticInvokeCapability('')`, meaning the capability to
 /// reflect over all static members.
-const staticInvokeCapability = StaticInvokeCapability("");
+const staticInvokeCapability = StaticInvokeCapability('');
 
 /// Gives support for reflective invocation of static members (static methods,
 /// getters, and setters) that are annotated with instances of [metadataType]
@@ -131,9 +131,9 @@ class TopLevelInvokeCapability extends NamePatternCapability {
   const TopLevelInvokeCapability(String namePattern) : super(namePattern);
 }
 
-/// Short hand for `TopLevelInvokeCapability("")`, meaning the capability to
+/// Short hand for `TopLevelInvokeCapability('')`, meaning the capability to
 /// reflect over all top-level members.
-const topLevelInvokeCapability = TopLevelInvokeCapability("");
+const topLevelInvokeCapability = TopLevelInvokeCapability('');
 
 /// Gives support for reflective invocation of top-level members (top-level
 /// methods, getters, and setters) that are annotated with instances of
@@ -145,7 +145,7 @@ class TopLevelInvokeMetaCapability extends MetadataQuantifiedCapability {
 /// Gives support for reflective invocation of constructors (of all kinds)
 ///  matching [namePattern] interpreted as a regular expression.
 ///
-/// Constructors with the empty name are considered to have the name "new".
+/// Constructors with the empty name are considered to have the name 'new'.
 ///
 /// Note that this capability implies [TypeCapability], because there is no way
 /// to perform a `newInstance` operation without class mirrors.
@@ -154,9 +154,9 @@ class NewInstanceCapability extends NamePatternCapability
   const NewInstanceCapability(String namePattern) : super(namePattern);
 }
 
-/// Short hand for `const NewInstanceCapability("")`, meaning the capability to
+/// Short hand for `const NewInstanceCapability('')`, meaning the capability to
 /// reflect over all constructors.
-const newInstanceCapability = NewInstanceCapability("");
+const newInstanceCapability = NewInstanceCapability('');
 
 /// Gives support for reflective invocation
 /// of constructors (of all kinds) annotated by instances of [metadataType]
@@ -267,9 +267,9 @@ class InvokingCapability extends NamePatternCapability
   const InvokingCapability(String namePattern) : super(namePattern);
 }
 
-/// Short hand for `InvokingCapability("")`, meaning the capability to
+/// Short hand for `InvokingCapability('')`, meaning the capability to
 /// reflect over all top-level and static members.
-const invokingCapability = InvokingCapability("");
+const invokingCapability = InvokingCapability('');
 
 /// Gives the capabilities of all the capabilities requested by
 /// [InstanceInvokeMetaCapability]([metadata]),
@@ -484,7 +484,7 @@ class _NoSuchCapabilityErrorImpl extends Error
   _NoSuchCapabilityErrorImpl(String message) : _message = message;
 
   @override
-  toString() => _message;
+  String toString() => _message;
 }
 
 enum StringInvocationKind { method, getter, setter, constructor }
@@ -533,41 +533,41 @@ class ReflectableNoSuchMethodError extends Error
       this.kind,
       this.existingArgumentNames);
 
-  get invocation =>
+  StringInvocation get invocation =>
       _StringInvocation(memberName, positionalArguments, namedArguments, kind);
 
   @override
-  toString() {
+  String toString() {
     String kindName;
     switch (kind) {
       case StringInvocationKind.getter:
-        kindName = "getter";
+        kindName = 'getter';
         break;
       case StringInvocationKind.setter:
-        kindName = "setter";
+        kindName = 'setter';
         break;
       case StringInvocationKind.method:
-        kindName = "method";
+        kindName = 'method';
         break;
       case StringInvocationKind.constructor:
-        kindName = "constructor";
+        kindName = 'constructor';
         break;
       default:
         // Reaching this point is a bug, so we ought to do this:
-        // `throw unreachableError("Unexpected StringInvocationKind value");`
+        // `throw unreachableError('Unexpected StringInvocationKind value');`
         // but it is a bit harsh to raise an exception because of a slightly
         // imprecise diagnostic message, so we use a default instead.
-        kindName = "";
+        kindName = '';
     }
-    String description = "NoSuchCapabilityError: no capability to invoke the "
-        "$kindName '$memberName'\n"
-        "Receiver: $receiver\n"
-        "Arguments: $positionalArguments\n";
+    var description = 'NoSuchCapabilityError: no capability to invoke the '
+        '$kindName "$memberName"\n'
+        'Receiver: $receiver\n'
+        'Arguments: $positionalArguments\n';
     if (namedArguments != null) {
-      description += "Named arguments: $namedArguments\n";
+      description += 'Named arguments: $namedArguments\n';
     }
     if (existingArgumentNames != null) {
-      description += "Existing argument names: $existingArgumentNames\n";
+      description += 'Existing argument names: $existingArgumentNames\n';
     }
     return description;
   }

--- a/lib/mirrors.dart
+++ b/lib/mirrors.dart
@@ -455,7 +455,7 @@ abstract class InstanceMirror implements ObjectMirror {
   /// exception is thrown.
   ///
   /// Required capabilities: [reflectee] does not require any capabilities.
-  get reflectee;
+  Object get reflectee;
 
   /// Whether this mirror is equal to [other].
   ///
@@ -489,7 +489,7 @@ abstract class InstanceMirror implements ObjectMirror {
   ///     }
   ///
   /// Required capabilities: [delegate] requires the [delegateCapability].
-  delegate(Invocation invocation);
+  dynamic delegate(Invocation invocation);
 }
 
 /// A [ClosureMirror] reflects a closure.

--- a/lib/mirrors.dart
+++ b/lib/mirrors.dart
@@ -464,9 +464,11 @@ abstract class InstanceMirror implements ObjectMirror {
   /// [:identical(reflectee, other.reflectee):].
   ///
   /// Required capabilities: [operator ==] does not require any capabilities.
+  @override
   bool operator ==(other);
 
   /// Override requested by linter.
+  @override
   int get hashCode;
 
   /// Performs [invocation] on [reflectee].
@@ -576,9 +578,11 @@ abstract class LibraryMirror implements DeclarationMirror, ObjectMirror {
   ///    reflected by [other] are the same library in the same isolate.
   ///
   /// Required capabilities: [operator ==] does not require any capabilities.
+  @override
   bool operator ==(other);
 
   /// Override requested by linter.
+  @override
   int get hashCode;
 
   /// Returns a list of the imports and exports in this library;
@@ -970,9 +974,11 @@ abstract class ClassMirror implements TypeMirror, ObjectMirror {
   /// implies that the reflected class and [other] have equal type arguments.
   ///
   /// Required capabilities: [operator ==] does not require any capabilities.
+  @override
   bool operator ==(other);
 
   /// Override requested by linter.
+  @override
   int get hashCode;
 
   /// Returns whether the class denoted by the receiver is a subclass of the
@@ -1077,9 +1083,11 @@ abstract class TypeVariableMirror extends TypeMirror {
   /// 2. [:simpleName == other.simpleName:] and [:owner == other.owner:].
   ///
   /// Required capabilities: [operator ==] does not require any capabilities.
+  @override
   bool operator ==(other);
 
   /// Override requested by linter.
+  @override
   int get hashCode;
 }
 
@@ -1248,9 +1256,11 @@ abstract class MethodMirror implements DeclarationMirror {
   /// 2. [:simpleName == other.simpleName:] and [:owner == other.owner:].
   ///
   /// Required capabilities: [operator ==] does not require any capabilities.
+  @override
   bool operator ==(other);
 
   /// Override requested by linter.
+  @override
   int get hashCode;
 }
 
@@ -1327,9 +1337,11 @@ abstract class VariableMirror implements DeclarationMirror {
   /// 2. [:simpleName == other.simpleName:] and [:owner == other.owner:].
   ///
   /// Required capabilities: [operator ==] does not require any capabilities.
+  @override
   bool operator ==(other);
 
   /// Override requested by linter.
+  @override
   int get hashCode;
 }
 
@@ -1338,6 +1350,7 @@ abstract class ParameterMirror implements VariableMirror {
   /// A mirror on the type of this parameter.
   ///
   /// Required capabilities: [type] requires a [TypeCapability].
+  @override
   TypeMirror get type;
 
   /// Returns [:true:] if the reflectee is an optional parameter.

--- a/lib/reflectable.dart
+++ b/lib/reflectable.dart
@@ -120,7 +120,7 @@ abstract class Reflectable extends implementation.ReflectableImpl
   /// but no entities are covered (that is, it is unused, so we don't have
   /// any reflection data for it) then [null] is returned.
   static Reflectable getInstance(Type type) {
-    for (Reflectable reflector in implementation.reflectors) {
+    for (var reflector in implementation.reflectors) {
       if (reflector.runtimeType == type) return reflector;
     }
     return null;

--- a/lib/reflectable_builder.dart
+++ b/lib/reflectable_builder.dart
@@ -28,6 +28,7 @@ class ReflectableBuilder implements Builder {
     await buildStep.writeAsString(outputId, generatedSource);
   }
 
+  @override
   Map<String, List<String>> get buildExtensions => const {
         '.dart': ['.reflectable.dart']
       };

--- a/lib/reflectable_builder.dart
+++ b/lib/reflectable_builder.dart
@@ -22,7 +22,7 @@ class ReflectableBuilder implements Builder {
     var resolver = buildStep.resolver;
     var inputId = buildStep.inputId;
     var outputId = inputId.changeExtension('.reflectable.dart');
-    List<LibraryElement> visibleLibraries = await resolver.libraries.toList();
+    var visibleLibraries = await resolver.libraries.toList();
     var generatedSource = await BuilderImplementation().buildMirrorLibrary(
         resolver, inputId, outputId, inputLibrary, visibleLibraries, true, []);
     await buildStep.writeAsString(outputId, generatedSource);
@@ -44,16 +44,16 @@ Future<BuildResult> reflectableBuild(List<String> arguments) async {
   if (arguments.isEmpty) {
     // Globbing may produce an empty argument list, and it might be ok,
     // but we should give at least notify the caller.
-    print("reflectable_builder: No arguments given, exiting.");
+    print('reflectable_builder: No arguments given, exiting.');
     return BuildResult(BuildStatus.success, []);
   } else {
     // TODO(eernst) feature: We should support some customization of
     // the settings, e.g., specifying options like `suppress_warnings`.
     var options = BuilderOptions(
-        <String, dynamic>{"entry_points": arguments, "formatted": true},
+        <String, dynamic>{'entry_points': arguments, 'formatted': true},
         isRoot: true);
     final builder = ReflectableBuilder(options);
-    List<BuilderApplication> builders = [
+    var builders = <BuilderApplication>[
       applyToRoot(builder, generateFor: InputSet(include: arguments))
     ];
     var packageGraph = PackageGraph.forThisPackage();

--- a/lib/reflectable_builder.dart
+++ b/lib/reflectable_builder.dart
@@ -5,7 +5,6 @@
 library reflectable.reflectable_builder;
 
 import 'dart:async';
-import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
 import 'package:build_config/build_config.dart';
 import 'package:build_runner_core/build_runner_core.dart';

--- a/lib/src/builder_implementation.dart
+++ b/lib/src/builder_implementation.dart
@@ -1609,29 +1609,17 @@ class _ReflectorDomain {
           ? topLevelVariables.indexOf(variable)
           : fields.indexOf(variable);
       assert(variableMirrorIndex != null);
-      int reflectedTypeIndex = reflectedTypeRequested
-          ? _typeCodeIndex(accessorElement.variable.type, await classes,
-              reflectedTypes, reflectedTypesOffset, typedefs)
-          : constants.NO_CAPABILITY_INDEX;
-      // Do not check `reflectedTypeIndex != null`, null means dynamic.
-      int dynamicReflectedTypeIndex = reflectedTypeRequested
-          ? _dynamicTypeCodeIndex(accessorElement.variable.type, await classes,
-              reflectedTypes, reflectedTypesOffset, typedefs)
-          : constants.NO_CAPABILITY_INDEX;
-      // Do not check `dynamicReflectedTypeIndex != null`, null means dynamic.
       int selfIndex = members.indexOf(accessorElement) + fields.length;
       assert(selfIndex != null);
       if (accessorElement.isGetter) {
         return 'r.ImplicitGetterMirrorImpl('
             '${await _constConstructionCode(importCollector)}, '
-            '$variableMirrorIndex, $reflectedTypeIndex, '
-            '$dynamicReflectedTypeIndex, $selfIndex)';
+            '$variableMirrorIndex, $selfIndex)';
       } else {
         assert(accessorElement.isSetter);
         return 'r.ImplicitSetterMirrorImpl('
             '${await _constConstructionCode(importCollector)}, '
-            '$variableMirrorIndex, $reflectedTypeIndex, '
-            '$dynamicReflectedTypeIndex, $selfIndex)';
+            '$variableMirrorIndex, $selfIndex)';
       }
     } else {
       // [element] is a method, a function, or an explicitly declared

--- a/lib/src/builder_implementation.dart
+++ b/lib/src/builder_implementation.dart
@@ -5,11 +5,13 @@
 library reflectable.src.builder_implementation;
 
 import 'dart:developer' as developer;
+import 'package:analyzer/dart/analysis/session.dart';
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
+import 'package:analyzer/dart/element/type_system.dart';
 import 'package:analyzer/src/dart/element/element.dart';
 import 'package:analyzer/src/dart/element/type.dart';
 import 'package:analyzer/src/dart/constant/evaluation.dart';
@@ -53,7 +55,7 @@ class ReflectionWorld {
   /// Used to collect the names of covered members during `generateCode`, then
   /// used by `generateSymbolMap` to generate code for a mapping from symbols
   /// to the corresponding strings.
-  final Set<String> memberNames = Set<String>();
+  final Set<String> memberNames = <String>{};
 
   ReflectionWorld(
       this.resolver,
@@ -75,7 +77,7 @@ class ReflectionWorld {
     void addSubtypeRelation(ClassElement supertype, ClassElement subtype) {
       Set<ClassElement> subtypesOfSupertype = subtypes[supertype];
       if (subtypesOfSupertype == null) {
-        subtypesOfSupertype = Set<ClassElement>();
+        subtypesOfSupertype = <ClassElement>{};
         subtypes[supertype] = subtypesOfSupertype;
       }
       subtypesOfSupertype.add(subtype);
@@ -134,8 +136,8 @@ class ReflectionWorld {
   /// needed to enable the correct behavior for all [reflectors].
   Future<String> generateCode() async {
     var typedefs = <FunctionType, int>{};
-    var typeVariablesInScope = Set<String>(); // None at top level.
-    String typedefsCode = "\n";
+    var typeVariablesInScope = <String>{}; // None at top level.
+    String typedefsCode = '\n';
     List<String> reflectorsCode = [];
     for (_ReflectorDomain reflector in reflectors) {
       String reflectorCode =
@@ -146,16 +148,16 @@ class ReflectionWorld {
               dartType, importCollector, typeVariablesInScope, typedefs,
               useNameOfGenericFunctionType: false);
           typedefsCode +=
-              "\ntypedef ${_typedefName(typedefs[dartType])} = $body;";
+              '\ntypedef ${_typedefName(typedefs[dartType])} = $body;';
         }
         typedefs.clear();
       }
       reflectorsCode
-          .add("${await reflector._constConstructionCode(importCollector)}: "
-              "$reflectorCode");
+          .add('${await reflector._constConstructionCode(importCollector)}: '
+              '$reflectorCode');
     }
-    return "final _data = <r.Reflectable, r.ReflectorData>"
-        "${_formatAsMap(reflectorsCode)};$typedefsCode";
+    return 'final _data = <r.Reflectable, r.ReflectorData>'
+        '${_formatAsMap(reflectorsCode)};$typedefsCode';
   }
 
   /// Returns code which defines a mapping from symbols for covered members
@@ -168,10 +170,10 @@ class ReflectionWorld {
       // Generate the mapping when requested, even if it is empty.
       String mapping = _formatAsMap(
           memberNames.map((String name) => "const Symbol(r'$name'): r'$name'"));
-      return "$mapping";
+      return '$mapping';
     } else {
       // The value `null` unambiguously indicates lack of capability.
-      return "null";
+      return 'null';
     }
   }
 }
@@ -250,7 +252,7 @@ class ClassElementEnhancedSet implements Set<ClassElement> {
   }
 
   @override
-  Iterable<T> map<T>(T f(ClassElement element)) =>
+  Iterable<T> map<T>(T Function(ClassElement) f) =>
       classElements.items.map<T>(f);
 
   @override
@@ -260,7 +262,7 @@ class ClassElementEnhancedSet implements Set<ClassElement> {
   }
 
   @override
-  Iterable<ClassElement> where(bool f(ClassElement element)) {
+  Iterable<ClassElement> where(bool Function(ClassElement) f) {
     return classElements.items.where(f);
   }
 
@@ -274,32 +276,32 @@ class ClassElementEnhancedSet implements Set<ClassElement> {
   }
 
   @override
-  Iterable<T> expand<T>(Iterable<T> f(ClassElement element)) {
+  Iterable<T> expand<T>(Iterable<T> Function(ClassElement) f) {
     return classElements.items.expand<T>(f);
   }
 
   @override
-  void forEach(void f(ClassElement element)) => classElements.items.forEach(f);
+  void forEach(void Function(ClassElement) f) => classElements.items.forEach(f);
 
   @override
   ClassElement reduce(
-      ClassElement combine(ClassElement value, ClassElement element)) {
+      ClassElement Function(ClassElement, ClassElement) combine) {
     return classElements.items.reduce(combine);
   }
 
   @override
-  T fold<T>(T initialValue, T combine(T previousValue, ClassElement element)) {
+  T fold<T>(T initialValue, T Function(T, ClassElement) combine) {
     return classElements.items.fold<T>(initialValue, combine);
   }
 
   @override
-  bool every(bool f(ClassElement element)) => classElements.items.every(f);
+  bool every(bool Function(ClassElement) f) => classElements.items.every(f);
 
   @override
-  String join([String separator = ""]) => classElements.items.join(separator);
+  String join([String separator = '']) => classElements.items.join(separator);
 
   @override
-  bool any(bool f(ClassElement element)) => classElements.items.any(f);
+  bool any(bool Function(ClassElement) f) => classElements.items.any(f);
 
   @override
   List<ClassElement> toList({bool growable = true}) {
@@ -319,7 +321,7 @@ class ClassElementEnhancedSet implements Set<ClassElement> {
   Iterable<ClassElement> take(int count) => classElements.items.take(count);
 
   @override
-  Iterable<ClassElement> takeWhile(bool test(ClassElement value)) {
+  Iterable<ClassElement> takeWhile(bool Function(ClassElement) test) {
     return classElements.items.takeWhile(test);
   }
 
@@ -327,7 +329,7 @@ class ClassElementEnhancedSet implements Set<ClassElement> {
   Iterable<ClassElement> skip(int count) => classElements.items.skip(count);
 
   @override
-  Iterable<ClassElement> skipWhile(bool test(ClassElement value)) {
+  Iterable<ClassElement> skipWhile(bool Function(ClassElement) test) {
     return classElements.items.skipWhile(test);
   }
 
@@ -347,20 +349,20 @@ class ClassElementEnhancedSet implements Set<ClassElement> {
   ClassElement get single => classElements.items.single;
 
   @override
-  ClassElement firstWhere(bool test(ClassElement element),
-      {ClassElement orElse()}) {
+  ClassElement firstWhere(bool Function(ClassElement) test,
+      {ClassElement Function() orElse}) {
     return classElements.items.firstWhere(test, orElse: orElse);
   }
 
   @override
-  ClassElement lastWhere(bool test(ClassElement element),
-      {ClassElement orElse()}) {
+  ClassElement lastWhere(bool Function(ClassElement) test,
+      {ClassElement Function() orElse}) {
     return classElements.items.lastWhere(test, orElse: orElse);
   }
 
   @override
-  ClassElement singleWhere(bool test(ClassElement element),
-      {ClassElement orElse()}) {
+  ClassElement singleWhere(bool Function(ClassElement) test,
+      {ClassElement Function() orElse}) {
     return classElements.items.singleWhere(test);
   }
 
@@ -431,8 +433,8 @@ class ClassElementEnhancedSet implements Set<ClassElement> {
   }
 
   @override
-  void removeWhere(bool test(ClassElement element)) {
-    Set<ClassElement> toRemove = Set<ClassElement>();
+  void removeWhere(bool Function(ClassElement) test) {
+    var toRemove = <ClassElement>{};
     for (ClassElement classElement in classElements.items) {
       if (test(classElement)) toRemove.add(classElement);
     }
@@ -440,7 +442,7 @@ class ClassElementEnhancedSet implements Set<ClassElement> {
   }
 
   @override
-  void retainWhere(bool test(ClassElement element)) {
+  void retainWhere(bool Function(ClassElement) test) {
     bool inverted_test(ClassElement element) => !test(element);
     removeWhere(inverted_test);
   }
@@ -529,15 +531,16 @@ class ErasableDartType {
   ErasableDartType(this.dartType, {this.erased});
 
   @override
-  operator ==(other) =>
+  bool operator ==(other) =>
       other is ErasableDartType &&
       other.dartType == dartType &&
       other.erased == erased;
 
   @override
   int get hashCode => dartType.hashCode ^ erased.hashCode;
+
   @override
-  String toString() => "ErasableDartType($dartType, $erased)";
+  String toString() => 'ErasableDartType($dartType, $erased)';
 }
 
 /// Models the shape of a parameter list, which enables invocation to detect
@@ -566,13 +569,13 @@ class ParameterListShape {
       numberOfOptionalPositionalParameters.hashCode;
 
   String get code {
-    String names = "null";
+    String names = 'null';
     if (namesOfNamedParameters.isNotEmpty) {
-      Iterable<String> symbols = namesOfNamedParameters.map((name) => "#$name");
-      names = "const ${_formatAsDynamicList(symbols)}";
+      Iterable<String> symbols = namesOfNamedParameters.map((name) => '#$name');
+      names = 'const ${_formatAsDynamicList(symbols)}';
     }
-    return "const [$numberOfPositionalParameters, "
-        "$numberOfOptionalPositionalParameters, $names]";
+    return 'const [$numberOfPositionalParameters, '
+        '$numberOfOptionalPositionalParameters, $names]';
   }
 }
 
@@ -645,10 +648,7 @@ class _ReflectorDomain {
     _classes = ClassElementEnhancedSet(this);
   }
 
-  // TODO(eernst) future: Perhaps reconsider what the best strategy
-  // for caching is.
-  Map<ClassElement, Map<String, ExecutableElement>> _instanceMemberCache =
-      <ClassElement, Map<String, ExecutableElement>>{};
+  final _instanceMemberCache = <ClassElement, Map<String, ExecutableElement>>{};
 
   /// Returns a string that evaluates to a closure invoking [constructor] with
   /// the given arguments.
@@ -690,25 +690,25 @@ class _ReflectorDomain {
     // would suppress an error in a very-hard-to-explain case, so that's safer
     // in a sense, but too weird.
     if (constructor.library.isDartCore &&
-        constructor.enclosingElement.name == "List" &&
-        constructor.name == "") {
-      return "(b) => ([length]) => "
-          "b ? (length == null ? List() : List(length)) : null";
+        constructor.enclosingElement.name == 'List' &&
+        constructor.name == '') {
+      return '(b) => ([length]) => '
+          'b ? (length == null ? List() : List(length)) : null';
     }
 
     String positionals =
         Iterable.generate(requiredPositionalCount, (int i) => parameterNames[i])
-            .join(", ");
+            .join(', ');
 
     List<String> optionalsWithDefaultList = [];
     for (int i = 0; i < optionalPositionalCount; i++) {
       String code = await _extractDefaultValueCode(
           importCollector, constructor.parameters[requiredPositionalCount + i]);
-      String defaultPart = code.isEmpty ? "" : " = $code";
+      String defaultPart = code.isEmpty ? '' : ' = $code';
       optionalsWithDefaultList
-          .add("${parameterNames[requiredPositionalCount + i]}$defaultPart");
+          .add('${parameterNames[requiredPositionalCount + i]}$defaultPart');
     }
-    String optionalsWithDefaults = optionalsWithDefaultList.join(", ");
+    String optionalsWithDefaults = optionalsWithDefaultList.join(', ');
 
     List<String> namedWithDefaultList = [];
     for (int i = 0; i < namedParameterNames.length; i++) {
@@ -723,12 +723,12 @@ class _ReflectorDomain {
       String defaultPart = code.isEmpty ? '' : ' = $code';
       namedWithDefaultList.add('${parameterElement.name}$defaultPart');
     }
-    String namedWithDefaults = namedWithDefaultList.join(", ");
+    String namedWithDefaults = namedWithDefaultList.join(', ');
 
     String optionalArguments = Iterable.generate(optionalPositionalCount,
-        (int i) => parameterNames[i + requiredPositionalCount]).join(", ");
+        (int i) => parameterNames[i + requiredPositionalCount]).join(', ');
     String namedArguments =
-        namedParameterNames.map((String name) => "$name: $name").join(", ");
+        namedParameterNames.map((String name) => '$name: $name').join(', ');
 
     List<String> parameterParts = <String>[];
     List<String> argumentParts = <String>[];
@@ -738,23 +738,23 @@ class _ReflectorDomain {
       argumentParts.add(positionals);
     }
     if (optionalPositionalCount != 0) {
-      parameterParts.add("[$optionalsWithDefaults]");
+      parameterParts.add('[$optionalsWithDefaults]');
       argumentParts.add(optionalArguments);
     }
     if (namedParameterNames.isNotEmpty) {
-      parameterParts.add("{${namedWithDefaults}}");
+      parameterParts.add('{${namedWithDefaults}}');
       argumentParts.add(namedArguments);
     }
 
-    String doRunArgument = "b";
+    String doRunArgument = 'b';
     while (parameterNames.contains(doRunArgument)) {
-      doRunArgument = doRunArgument + "b";
+      doRunArgument = doRunArgument + 'b';
     }
 
     String prefix = importCollector._getPrefix(constructor.library);
     return ('($doRunArgument) => (${parameterParts.join(', ')}) => '
         '$doRunArgument ? $prefix${await _nameOfConstructor(constructor)}'
-        '(${argumentParts.join(", ")}) : null');
+        '(${argumentParts.join(', ')}) : null');
   }
 
   /// The code of the const-construction of this reflector.
@@ -763,9 +763,9 @@ class _ReflectorDomain {
     String prefix = importCollector._getPrefix(_reflector.library);
     if (_isPrivateName(_reflector.name)) {
       await _severe(
-          "Cannot access private name `${_reflector.name}`", _reflector);
+          'Cannot access private name `${_reflector.name}`', _reflector);
     }
-    return "const $prefix${_reflector.name}()";
+    return 'const $prefix${_reflector.name}()';
   }
 
   /// Generate the code which will create a `ReflectorData` instance
@@ -787,8 +787,8 @@ class _ReflectorDomain {
     // Reflected types not in `classes`; appended to `ReflectorData.types`.
     Enumerator<ErasableDartType> reflectedTypes =
         Enumerator<ErasableDartType>();
-    Set<String> instanceGetterNames = Set<String>();
-    Set<String> instanceSetterNames = Set<String>();
+    var instanceGetterNames = <String>{};
+    var instanceSetterNames = <String>{};
 
     // Library and class related collections.
     Enumerator<ExecutableElement> members = Enumerator<ExecutableElement>();
@@ -874,8 +874,8 @@ class _ReflectorDomain {
             topLevelVariables.add(variable);
           } else {
             await _severe(
-                "This kind of variable is not yet supported"
-                " (${variable.runtimeType})",
+                'This kind of variable is not yet supported'
+                ' (${variable.runtimeType})',
                 variable);
           }
         }
@@ -917,7 +917,7 @@ class _ReflectorDomain {
 
       bool hasObject = false;
       bool mustHaveObject = false;
-      Set<ClassElement> classesToAdd = Set<ClassElement>();
+      var classesToAdd = <ClassElement>{};
       ClassElement anyClassElement;
       for (ClassElement classElement in await classes) {
         if (classElement.instantiate().isObject) {
@@ -966,7 +966,7 @@ class _ReflectorDomain {
       members.items.forEach((ExecutableElement element) {
         int count = 0;
         int optionalCount = 0;
-        Set<String> names = Set<String>();
+        var names = <String>{};
         for (ParameterElement parameter in element.parameters) {
           if (!parameter.isNamed) count++;
           if (parameter.isOptionalPositional) optionalCount++;
@@ -1013,7 +1013,7 @@ class _ReflectorDomain {
             typeParameterElement, importCollector, objectClassElement));
       }
     }
-    String classMirrorsCode = _formatAsList("m.TypeMirror", typeMirrorsList);
+    String classMirrorsCode = _formatAsList('m.TypeMirror', typeMirrorsList);
 
     // Generate code for creation of getter and setter closures.
     String gettersCode = _formatAsMap(instanceGetterNames.map(_gettingClosure));
@@ -1042,7 +1042,7 @@ class _ReflectorDomain {
           typedefs,
           reflectedTypeRequested));
     }
-    String membersCode = "null";
+    String membersCode = 'null';
     if (_capabilities._impliesDeclarations) {
       List<String> methodsList = [];
       for (ExecutableElement executableElement in members.items) {
@@ -1063,11 +1063,11 @@ class _ReflectorDomain {
         yield* fieldsList;
         yield* methodsList;
       }();
-      membersCode = _formatAsList("m.DeclarationMirror", membersList);
+      membersCode = _formatAsList('m.DeclarationMirror', membersList);
     }
 
     // Generate code for creation of parameter mirrors.
-    String parameterMirrorsCode = "null";
+    String parameterMirrorsCode = 'null';
     if (_capabilities._impliesDeclarations) {
       List<String> parametersList = [];
       for (ParameterElement element in parameters.items) {
@@ -1081,7 +1081,7 @@ class _ReflectorDomain {
             typedefs,
             reflectedTypeRequested));
       }
-      parameterMirrorsCode = _formatAsList("m.ParameterMirror", parametersList);
+      parameterMirrorsCode = _formatAsList('m.ParameterMirror', parametersList);
     }
 
     // Generate code for listing [Type] instances.
@@ -1098,12 +1098,12 @@ class _ReflectorDomain {
             erasableDartType.dartType, importCollector, typedefs));
       }
     }
-    String typesCode = _formatAsList("Type", typesCodeList);
+    String typesCode = _formatAsList('Type', typesCodeList);
 
     // Generate code for creation of library mirrors.
     String librariesCode;
     if (!_capabilities._supportsLibraries) {
-      librariesCode = "null";
+      librariesCode = 'null';
     } else {
       List<String> librariesCodeList = [];
       for (_LibraryDomain library in libraries.items) {
@@ -1117,17 +1117,17 @@ class _ReflectorDomain {
             methodsOffset,
             importCollector));
       }
-      librariesCode = _formatAsList("m.LibraryMirror", librariesCodeList);
+      librariesCode = _formatAsList('m.LibraryMirror', librariesCodeList);
     }
 
     String parameterListShapesCode = _formatAsDynamicList(parameterListShapes
         .items
         .map((ParameterListShape shape) => shape.code));
 
-    return "r.ReflectorData($classMirrorsCode, $membersCode, "
-        "$parameterMirrorsCode, $typesCode, $reflectedTypesOffset, "
-        "$gettersCode, $settersCode, $librariesCode, "
-        "$parameterListShapesCode)";
+    return 'r.ReflectorData($classMirrorsCode, $membersCode, '
+        '$parameterMirrorsCode, $typesCode, $reflectedTypesOffset, '
+        '$gettersCode, $settersCode, $librariesCode, '
+        '$parameterListShapesCode)';
   }
 
   Future<int> _computeTypeIndexBase(Element typeElement, bool isVoid,
@@ -1225,7 +1225,7 @@ class _ReflectorDomain {
               typesIndices.add(0);
             }
           }
-          return _formatAsConstList("int", typesIndices);
+          return _formatAsConstList('int', typesIndices);
         } else {
           return 'null';
         }
@@ -1254,7 +1254,7 @@ class _ReflectorDomain {
     } else if (element.enclosingElement is CompilationUnitElement) {
       return _libraries.indexOf(element.enclosingElement.enclosingElement);
     }
-    await _severe("Unexpected kind of request for owner");
+    await _severe('Unexpected kind of request for owner');
     return 0;
   }
 
@@ -1295,11 +1295,11 @@ class _ReflectorDomain {
         (await classes).indexOf(typeParameterElement.enclosingElement);
     // TODO(eernst) implement: Update when type variables support metadata.
     String metadataCode =
-        _capabilities._supportsMetadata ? "<Object>[]" : "null";
+        _capabilities._supportsMetadata ? '<Object>[]' : 'null';
     return "r.TypeVariableMirrorImpl(r'${typeParameterElement.name}', "
         "r'${_qualifiedTypeParameterName(typeParameterElement)}', "
-        "${await _constConstructionCode(importCollector)}, "
-        "$upperBoundIndex, $ownerIndex, $metadataCode)";
+        '${await _constConstructionCode(importCollector)}, '
+        '$upperBoundIndex, $ownerIndex, $metadataCode)';
   }
 
   Future<String> _classMirrorCode(
@@ -1347,17 +1347,17 @@ class _ReflectorDomain {
     });
 
     String declarationsCode = _capabilities._impliesDeclarations
-        ? _formatAsConstList("int", () sync* {
+        ? _formatAsConstList('int', () sync* {
             yield* fieldsIndices;
             yield* methodsIndices;
           }())
-        : "const <int>[${constants.NO_CAPABILITY_INDEX}]";
+        : 'const <int>[${constants.NO_CAPABILITY_INDEX}]';
 
     // All instance members belong to the behavioral interface, so they
     // also get an offset of `fields.length`.
-    String instanceMembersCode = "null";
+    String instanceMembersCode = 'null';
     if (_capabilities._impliesDeclarations) {
-      instanceMembersCode = _formatAsConstList("int",
+      instanceMembersCode = _formatAsConstList('int',
           classDomain._instanceMembers.map((ExecutableElement element) {
         // TODO(eernst) implement: The "magic" default constructor has
         // index: NO_CAPABILITY_INDEX; adjust this when support for it has
@@ -1371,9 +1371,9 @@ class _ReflectorDomain {
 
     // All static members belong to the behavioral interface, so they
     // also get an offset of `fields.length`.
-    String staticMembersCode = "null";
+    String staticMembersCode = 'null';
     if (_capabilities._impliesDeclarations) {
-      staticMembersCode = _formatAsConstList("int",
+      staticMembersCode = _formatAsConstList('int',
           classDomain._staticMembers.map((ExecutableElement element) {
         int index = members.indexOf(element);
         return index == null
@@ -1385,19 +1385,19 @@ class _ReflectorDomain {
     ClassElement classElement = classDomain._classElement;
     ClassElement superclass = (await classes).superclassOf(classElement);
 
-    String superclassIndex = "${constants.NO_CAPABILITY_INDEX}";
+    String superclassIndex = '${constants.NO_CAPABILITY_INDEX}';
     if (_capabilities._impliesTypeRelations) {
       // [Object]'s superclass is reported as `null`: it does not exist and
       // hence we cannot decide whether it's supported or unsupported.; by
       // convention we make it supported and report it in the same way as
       // 'dart:mirrors'. Other superclasses use `NO_CAPABILITY_INDEX` to
       // indicate missing support.
-      superclassIndex =
-          (classElement is! MixinApplication && classElement.instantiate().isObject)
-              ? "null"
-              : ((await classes).contains(superclass))
-                  ? "${(await classes).indexOf(superclass)}"
-                  : "${constants.NO_CAPABILITY_INDEX}";
+      superclassIndex = (classElement is! MixinApplication &&
+              classElement.instantiate().isObject)
+          ? 'null'
+          : ((await classes).contains(superclass))
+              ? '${(await classes).indexOf(superclass)}'
+              : '${constants.NO_CAPABILITY_INDEX}';
     }
 
     String constructorsCode;
@@ -1414,8 +1414,8 @@ class _ReflectorDomain {
       constructorsCode = _formatAsMap(mapEntries);
     }
 
-    String staticGettersCode = "const {}";
-    String staticSettersCode = "const {}";
+    String staticGettersCode = 'const {}';
+    String staticSettersCode = 'const {}';
     if (classElement is! MixinApplication) {
       List<String> staticGettersCodeList = [];
       for (MethodElement method in classDomain._declaredMethods) {
@@ -1453,7 +1453,7 @@ class _ReflectorDomain {
               : (await classes).indexOf(classElement));
       // We may not have support for the given class, in which case we must
       // correct the `null` from `indexOf` to indicate missing capability.
-      if (mixinIndex == null) mixinIndex = constants.NO_CAPABILITY_INDEX;
+      mixinIndex ??= constants.NO_CAPABILITY_INDEX;
     }
 
     int ownerIndex = _capabilities._supportsLibraries
@@ -1461,7 +1461,7 @@ class _ReflectorDomain {
         : constants.NO_CAPABILITY_INDEX;
 
     String superinterfaceIndices =
-        "const <int>[${constants.NO_CAPABILITY_INDEX}]";
+        'const <int>[${constants.NO_CAPABILITY_INDEX}]';
     if (_capabilities._impliesTypeRelations) {
       superinterfaceIndices = _formatAsConstList(
           'int',
@@ -1476,12 +1476,12 @@ class _ReflectorDomain {
       classMetadataCode = await _extractMetadataCode(
           classElement, _resolver, importCollector, _generatedLibraryId);
     } else {
-      classMetadataCode = "null";
+      classMetadataCode = 'null';
     }
 
     int classIndex = (await classes).indexOf(classElement);
 
-    String parameterListShapesCode = "null";
+    String parameterListShapesCode = 'null';
     if (_capabilities._impliesParameterListShapes) {
       Iterable<ExecutableElement> membersList = () sync* {
         yield* classDomain._instanceMembers;
@@ -1501,12 +1501,12 @@ class _ReflectorDomain {
     if (classElement.typeParameters.isEmpty) {
       return "r.NonGenericClassMirrorImpl(r'${classDomain._simpleName}', "
           "r'${_qualifiedName(classElement)}', $descriptor, $classIndex, "
-          "${await _constConstructionCode(importCollector)}, "
-          "$declarationsCode, $instanceMembersCode, $staticMembersCode, "
-          "$superclassIndex, $staticGettersCode, $staticSettersCode, "
-          "$constructorsCode, $ownerIndex, $mixinIndex, "
-          "$superinterfaceIndices, $classMetadataCode, "
-          "$parameterListShapesCode)";
+          '${await _constConstructionCode(importCollector)}, '
+          '$declarationsCode, $instanceMembersCode, $staticMembersCode, '
+          '$superclassIndex, $staticGettersCode, $staticSettersCode, '
+          '$constructorsCode, $ownerIndex, $mixinIndex, '
+          '$superinterfaceIndices, $classMetadataCode, '
+          '$parameterListShapesCode)';
     } else {
       // We are able to match up a given instance with a given generic type
       // by checking that the instance `is` an instance of the fully dynamic
@@ -1529,10 +1529,10 @@ class _ReflectorDomain {
         // https://github.com/dart-lang/sdk/issues/25344 for more details.
         // However, the result that we will return is well-defined, because
         // no object can be an instance of an anonymous mixin application.
-        isCheckList.add("(o) => false");
+        isCheckList.add('(o) => false');
       } else {
         String prefix = importCollector._getPrefix(classElement.library);
-        isCheckList.add("(o) { return o is $prefix${classElement.name}");
+        isCheckList.add('(o) { return o is $prefix${classElement.name}');
 
         // Add 'is checks' to [list], based on [classElement].
         Future<void> helper(
@@ -1547,17 +1547,17 @@ class _ReflectorDomain {
               await helper(list, subtype);
             } else {
               String prefix = importCollector._getPrefix(subtype.library);
-              list.add(" && o is! $prefix${subtype.name}");
+              list.add(' && o is! $prefix${subtype.name}');
             }
           }
         }
 
         await helper(isCheckList, classElement);
-        isCheckList.add("; }");
+        isCheckList.add('; }');
       }
       String isCheckCode = isCheckList.join();
 
-      String typeParameterIndices = "null";
+      String typeParameterIndices = 'null';
       if (_capabilities._impliesDeclarations) {
         int indexOf(TypeParameterElement typeParameter) =>
             typeParameters.indexOf(typeParameter) + typeParametersOffset;
@@ -1577,13 +1577,13 @@ class _ReflectorDomain {
 
       return "r.GenericClassMirrorImpl(r'${classDomain._simpleName}', "
           "r'${_qualifiedName(classElement)}', $descriptor, $classIndex, "
-          "${await _constConstructionCode(importCollector)}, "
-          "$declarationsCode, $instanceMembersCode, $staticMembersCode, "
-          "$superclassIndex, $staticGettersCode, $staticSettersCode, "
-          "$constructorsCode, $ownerIndex, $mixinIndex, "
-          "$superinterfaceIndices, $classMetadataCode, "
-          "$parameterListShapesCode, $isCheckCode, "
-          "$typeParameterIndices, $dynamicReflectedTypeIndex)";
+          '${await _constConstructionCode(importCollector)}, '
+          '$declarationsCode, $instanceMembersCode, $staticMembersCode, '
+          '$superclassIndex, $staticGettersCode, $staticSettersCode, '
+          '$constructorsCode, $ownerIndex, $mixinIndex, '
+          '$superinterfaceIndices, $classMetadataCode, '
+          '$parameterListShapesCode, $isCheckCode, '
+          '$typeParameterIndices, $dynamicReflectedTypeIndex)';
     }
   }
 
@@ -1646,7 +1646,7 @@ class _ReflectorDomain {
                 importCollector,
                 typedefs);
       }
-      String parameterIndicesCode = _formatAsConstList("int",
+      String parameterIndicesCode = _formatAsConstList('int',
           element.parameters.map((ParameterElement parameterElement) {
         return parameters.indexOf(parameterElement);
       }));
@@ -1669,10 +1669,10 @@ class _ReflectorDomain {
               element, _resolver, importCollector, _generatedLibraryId)
           : null;
       return "r.MethodMirrorImpl(r'${element.name}', $descriptor, "
-          "$ownerIndex, $returnTypeIndex, $reflectedReturnTypeIndex, "
-          "$dynamicReflectedReturnTypeIndex, "
-          "$reflectedTypeArgumentsOfReturnType, $parameterIndicesCode, "
-          "${await _constConstructionCode(importCollector)}, $metadataCode)";
+          '$ownerIndex, $returnTypeIndex, $reflectedReturnTypeIndex, '
+          '$dynamicReflectedReturnTypeIndex, '
+          '$reflectedTypeArgumentsOfReturnType, $parameterIndicesCode, '
+          '${await _constConstructionCode(importCollector)}, $metadataCode)';
     }
   }
 
@@ -1714,10 +1714,10 @@ class _ReflectorDomain {
       metadataCode = null;
     }
     return "r.VariableMirrorImpl(r'${element.name}', $descriptor, "
-        "$ownerIndex, ${await _constConstructionCode(importCollector)}, "
-        "$classMirrorIndex, $reflectedTypeIndex, "
-        "$dynamicReflectedTypeIndex, $reflectedTypeArguments, "
-        "$metadataCode)";
+        '$ownerIndex, ${await _constConstructionCode(importCollector)}, '
+        '$classMirrorIndex, $reflectedTypeIndex, '
+        '$dynamicReflectedTypeIndex, $reflectedTypeArguments, '
+        '$metadataCode)';
   }
 
   Future<String> _fieldMirrorCode(
@@ -1757,9 +1757,9 @@ class _ReflectorDomain {
       metadataCode = null;
     }
     return "r.VariableMirrorImpl(r'${element.name}', $descriptor, "
-        "$ownerIndex, ${await _constConstructionCode(importCollector)}, "
-        "$classMirrorIndex, $reflectedTypeIndex, "
-        "$dynamicReflectedTypeIndex, $reflectedTypeArguments, $metadataCode)";
+        '$ownerIndex, ${await _constConstructionCode(importCollector)}, '
+        '$classMirrorIndex, $reflectedTypeIndex, '
+        '$dynamicReflectedTypeIndex, $reflectedTypeArguments, $metadataCode)';
   }
 
   /// Returns the index into `ReflectorData.types` of the [Type] object
@@ -1901,14 +1901,14 @@ class _ReflectorDomain {
       {bool useNameOfGenericFunctionType = true}) async {
     Future<String> fail() async {
       log.warning(await _formatDiagnosticMessage(
-          "Attempt to generate code for an "
-          "unsupported kind of type: $dartType (${dartType.runtimeType}). "
-          "Generating `dynamic`.",
+          'Attempt to generate code for an '
+          'unsupported kind of type: $dartType (${dartType.runtimeType}). '
+          'Generating `dynamic`.',
           dartType.element));
-      return "dynamic";
+      return 'dynamic';
     }
 
-    if (dartType.isDynamic) return "dynamic";
+    if (dartType.isDynamic) return 'dynamic';
     if (dartType is InterfaceType) {
       ClassElement classElement = dartType.element;
       if ((classElement is MixinApplication &&
@@ -1918,7 +1918,7 @@ class _ReflectorDomain {
       }
       String prefix = importCollector._getPrefix(classElement.library);
       if (classElement.typeParameters.isEmpty) {
-        return "$prefix${classElement.name}";
+        return '$prefix${classElement.name}';
       } else {
         if (dartType.typeArguments.every(
             (type) => _hasNoFreeTypeVariables(type, typeVariablesInScope))) {
@@ -1929,7 +1929,7 @@ class _ReflectorDomain {
                 useNameOfGenericFunctionType: useNameOfGenericFunctionType));
           }
           String arguments = argumentList.join(', ');
-          return "$prefix${classElement.name}<$arguments>";
+          return '$prefix${classElement.name}<$arguments>';
         } else {
           return await fail();
         }
@@ -1938,7 +1938,7 @@ class _ReflectorDomain {
       if (dartType is FunctionTypeAliasElement) {
         FunctionTypeAliasElement element = dartType.element;
         String prefix = importCollector._getPrefix(element.library);
-        return "$prefix${element.name}";
+        return '$prefix${element.name}';
       } else {
         // Generic function types need separate `typedef`s.
         if (dartType.typeFormals.isNotEmpty) {
@@ -1950,20 +1950,20 @@ class _ReflectorDomain {
             return _typedefName(dartTypeNumber);
           } else {
             // Requested: the spelled-out generic function type; continue.
-            (typeVariablesInScope ??= Set<String>())
+            (typeVariablesInScope ??= <String>{})
                 .addAll(dartType.typeFormals.map((element) => element.name));
           }
         }
         String returnType = await _typeCodeOfTypeArgument(dartType.returnType,
             importCollector, typeVariablesInScope, typedefs,
             useNameOfGenericFunctionType: useNameOfGenericFunctionType);
-        String typeArguments = "";
+        String typeArguments = '';
         if (dartType.typeFormals.isNotEmpty) {
           Iterable<String> typeArgumentList = dartType.typeFormals.map(
               (TypeParameterElement typeParameter) => typeParameter.toString());
-          typeArguments = "<${typeArgumentList.join(', ')}>";
+          typeArguments = '<${typeArgumentList.join(', ')}>';
         }
-        String argumentTypes = "";
+        String argumentTypes = '';
         if (dartType.normalParameterTypes.isNotEmpty) {
           List<String> normalParameterTypeList = [];
           for (DartType parameterType in dartType.normalParameterTypes) {
@@ -1980,9 +1980,9 @@ class _ReflectorDomain {
                 parameterType, importCollector, typeVariablesInScope, typedefs,
                 useNameOfGenericFunctionType: useNameOfGenericFunctionType));
           }
-          String connector = argumentTypes.isEmpty ? "" : ", ";
-          argumentTypes = "$argumentTypes$connector"
-              "[${optionalParameterTypeList.join(', ')}]";
+          String connector = argumentTypes.isEmpty ? '' : ', ';
+          argumentTypes = '$argumentTypes$connector'
+              '[${optionalParameterTypeList.join(', ')}]';
         }
         if (dartType.namedParameterTypes.isNotEmpty) {
           Map<String, DartType> parameterMap = dartType.namedParameterTypes;
@@ -1992,13 +1992,13 @@ class _ReflectorDomain {
             String typeCode = await _typeCodeOfTypeArgument(
                 parameterType, importCollector, typeVariablesInScope, typedefs,
                 useNameOfGenericFunctionType: useNameOfGenericFunctionType);
-            namedParameterTypeList.add("$typeCode $name");
+            namedParameterTypeList.add('$typeCode $name');
           }
-          String connector = argumentTypes.isEmpty ? "" : ", ";
-          argumentTypes = "$argumentTypes$connector"
-              "{${namedParameterTypeList.join(', ')}}";
+          String connector = argumentTypes.isEmpty ? '' : ', ';
+          argumentTypes = '$argumentTypes$connector'
+              '{${namedParameterTypeList.join(', ')}}';
         }
-        return "$returnType Function$typeArguments($argumentTypes)";
+        return '$returnType Function$typeArguments($argumentTypes)';
       }
     } else if (dartType is TypeParameterType &&
         typeVariablesInScope != null &&
@@ -2016,8 +2016,8 @@ class _ReflectorDomain {
   /// needed in order to obtain values from other libraries.
   Future<String> _typeCodeOfClass(DartType dartType,
       _ImportCollector importCollector, Map<FunctionType, int> typedefs) async {
-    var typeVariablesInScope = Set<String>(); // None at this level.
-    if (dartType.isDynamic) return "dynamic";
+    var typeVariablesInScope = <String>{}; // None at this level.
+    if (dartType.isDynamic) return 'dynamic';
     if (dartType is InterfaceType) {
       ClassElement classElement = dartType.element;
       if ((classElement is MixinApplication &&
@@ -2037,18 +2037,18 @@ class _ReflectorDomain {
       }
       String prefix = importCollector._getPrefix(classElement.library);
       if (classElement.typeParameters.isEmpty) {
-        return "$prefix${classElement.name}";
+        return '$prefix${classElement.name}';
       } else {
         if (dartType.typeArguments.every(_hasNoFreeTypeVariables)) {
           String typeArgumentCode = await _typeCodeOfTypeArgument(
               dartType, importCollector, typeVariablesInScope, typedefs,
               useNameOfGenericFunctionType: true);
-          return "const m.TypeValue<$typeArgumentCode>().type";
+          return 'const m.TypeValue<$typeArgumentCode>().type';
         } else {
           String arguments = dartType.typeArguments
               .map((DartType typeArgument) => typeArgument.toString())
               .join(', ');
-          return "const r.FakeType("
+          return 'const r.FakeType('
               "r'${_qualifiedName(classElement)}<$arguments>')";
         }
       }
@@ -2059,7 +2059,7 @@ class _ReflectorDomain {
       if (dartType.element is FunctionTypeAliasElement) {
         FunctionTypeAliasElement element = dartType.element;
         String prefix = importCollector._getPrefix(element.library);
-        return "$prefix${element.name}";
+        return '$prefix${element.name}';
       } else {
         if (dartType.typeFormals.isNotEmpty) {
           // `dartType` is a generic function type, so we must use a
@@ -2070,16 +2070,16 @@ class _ReflectorDomain {
         } else {
           String typeArgumentCode = await _typeCodeOfTypeArgument(
               dartType, importCollector, typeVariablesInScope, typedefs);
-          return "const m.TypeValue<$typeArgumentCode>().type";
+          return 'const m.TypeValue<$typeArgumentCode>().type';
         }
       }
     } else {
       log.warning(await _formatDiagnosticMessage(
-          "Attempt to generate code for an "
-          "unsupported kind of type: $dartType (${dartType.runtimeType}). "
-          "Generating `dynamic`.",
+          'Attempt to generate code for an '
+          'unsupported kind of type: $dartType (${dartType.runtimeType}). '
+          'Generating `dynamic`.',
           dartType.element));
-      return "dynamic";
+      return 'dynamic';
     }
   }
 
@@ -2095,7 +2095,7 @@ class _ReflectorDomain {
     DartType type = typeDefiningElement is ClassElement
         ? typeDefiningElement.instantiate()
         : null;
-    if (type?.isDynamic) return "dynamic";
+    if (type?.isDynamic) return 'dynamic';
     if (type is InterfaceType) {
       ClassElement classElement = type.element;
       if ((classElement is MixinApplication &&
@@ -2104,7 +2104,7 @@ class _ReflectorDomain {
         return "const r.FakeType(r'${_qualifiedName(classElement)}')";
       }
       String prefix = importCollector._getPrefix(classElement.library);
-      return "$prefix${classElement.name}";
+      return '$prefix${classElement.name}';
     } else {
       // This may be dead code: There is no test which reaches this point,
       // and it is not obvious how we could encounter any [type] which is not
@@ -2157,13 +2157,13 @@ class _ReflectorDomain {
       return index + methodsOffset;
     });
 
-    String declarationsCode = "const <int>[${constants.NO_CAPABILITY_INDEX}]";
+    String declarationsCode = 'const <int>[${constants.NO_CAPABILITY_INDEX}]';
     if (_capabilities._impliesDeclarations) {
       Iterable<int> declarationsIndices = () sync* {
         yield* variableIndices;
         yield* methodIndices;
       }();
-      declarationsCode = _formatAsConstList("int", declarationsIndices);
+      declarationsCode = _formatAsConstList('int', declarationsIndices);
     }
 
     // TODO(sigurdm) clarify: Find out how to get good uri's in a
@@ -2171,17 +2171,17 @@ class _ReflectorDomain {
     String uriCode =
         (_capabilities._supportsUri || _capabilities._supportsLibraries)
             ? "Uri.parse(r'reflectable://$libraryIndex/$library')"
-            : "null";
+            : 'null';
 
     String metadataCode;
     if (_capabilities._supportsMetadata) {
       metadataCode = await _extractMetadataCode(
           library, _resolver, importCollector, _generatedLibraryId);
     } else {
-      metadataCode = "null";
+      metadataCode = 'null';
     }
 
-    String parameterListShapesCode = "null";
+    String parameterListShapesCode = 'null';
     if (_capabilities._impliesParameterListShapes) {
       parameterListShapesCode = _formatAsMap(
           libraryDomain._declarations.map((ExecutableElement element) {
@@ -2194,9 +2194,9 @@ class _ReflectorDomain {
     }
 
     return "r.LibraryMirrorImpl(r'${library.name}', $uriCode, "
-        "${await _constConstructionCode(importCollector)}, "
-        "$declarationsCode, $gettersCode, $settersCode, $metadataCode, "
-        "$parameterListShapesCode)";
+        '${await _constConstructionCode(importCollector)}, '
+        '$declarationsCode, $gettersCode, $settersCode, $metadataCode, '
+        '$parameterListShapesCode)';
   }
 
   Future<String> _parameterMirrorCode(
@@ -2245,12 +2245,12 @@ class _ReflectorDomain {
           importCollector,
           typedefs);
     }
-    String metadataCode = "null";
+    String metadataCode = 'null';
     if (_capabilities._supportsMetadata) {
       // TODO(eernst): 'dart:*' is not considered valid. To survive, we
       // return the empty metadata for elements from 'dart:*'. Issue 173.
       if (_isPlatformLibrary(element.library)) {
-        metadataCode = "const []";
+        metadataCode = 'const []';
       } else {
         var resolvedLibrary =
             await element.session.getResolvedLibraryByElement(element.library);
@@ -2259,7 +2259,7 @@ class _ReflectorDomain {
         // then it has no metadata.
         FormalParameter node = declaration?.node;
         if (node == null) {
-          metadataCode = "const []";
+          metadataCode = 'const []';
         } else {
           metadataCode = await _extractMetadataCode(
               element, _resolver, importCollector, _generatedLibraryId);
@@ -2267,32 +2267,32 @@ class _ReflectorDomain {
       }
     }
     String code = await _extractDefaultValueCode(importCollector, element);
-    String defaultValueCode = code.isEmpty ? "null" : code;
+    String defaultValueCode = code.isEmpty ? 'null' : code;
     String parameterSymbolCode = descriptor & constants.namedAttribute != 0
-        ? "#${element.name}"
-        : "null";
+        ? '#${element.name}'
+        : 'null';
 
     return "r.ParameterMirrorImpl(r'${element.name}', $descriptor, "
-        "$ownerIndex, ${await _constConstructionCode(importCollector)}, "
-        "$classMirrorIndex, $reflectedTypeIndex, $dynamicReflectedTypeIndex, "
-        "$reflectedTypeArguments, $metadataCode, $defaultValueCode, "
-        "$parameterSymbolCode)";
+        '$ownerIndex, ${await _constConstructionCode(importCollector)}, '
+        '$classMirrorIndex, $reflectedTypeIndex, $dynamicReflectedTypeIndex, '
+        '$reflectedTypeArguments, $metadataCode, $defaultValueCode, '
+        '$parameterSymbolCode)';
   }
 
-  /// Given an [importCollector] and a [parameterElement], returns "" if there
+  /// Given an [importCollector] and a [parameterElement], returns '' if there
   /// is no default value, otherwise returns code for an expression that
   /// evaluates to said default value.
   Future<String> _extractDefaultValueCode(_ImportCollector importCollector,
       ParameterElement parameterElement) async {
     // TODO(eernst): 'dart:*' is not considered valid. To survive, we return
-    // "" for all declarations from there. Issue 173.
-    if (_isPlatformLibrary(parameterElement.library)) return "";
+    // '' for all declarations from there. Issue 173.
+    if (_isPlatformLibrary(parameterElement.library)) return '';
     var resolvedLibrary = await parameterElement.session
         .getResolvedLibraryByElement(parameterElement.library);
     var declaration = resolvedLibrary.getElementDeclaration(parameterElement);
     // The declaration can be null because the declaration is synthetic, e.g.,
     // the parameter of an induced setter; they have no default value.
-    if (declaration == null) return "";
+    if (declaration == null) return '';
     FormalParameter parameterNode = declaration.node;
     if (parameterNode is DefaultFormalParameter &&
         parameterNode.defaultValue != null) {
@@ -2305,7 +2305,7 @@ class _ReflectorDomain {
             defaultValue, importCollector, _generatedLibraryId, _resolver);
       }
     }
-    return "";
+    return '';
   }
 }
 
@@ -2419,7 +2419,7 @@ class _SuperclassFixedPoint extends FixedPoint<ClassElement> {
 /// Auxiliary function used by `classes`. Its `expand` method
 /// expands its argument to a fixed point, based on the `successors` method.
 Set<ClassElement> _mixinApplicationsOfClasses(Set<ClassElement> classes) {
-  Set<ClassElement> mixinApplications = Set<ClassElement>();
+  var mixinApplications = <ClassElement>{};
   for (ClassElement classElement in classes) {
     // Mixin-applications are handled when they are created.
     if (classElement is MixinApplication) continue;
@@ -2449,7 +2449,7 @@ Set<ClassElement> _mixinApplicationsOfClasses(Set<ClassElement> classes) {
 }
 
 /// Auxiliary type used by [_AnnotationClassFixedPoint].
-typedef _ClassDomain ElementToDomain(ClassElement _);
+typedef ElementToDomain = _ClassDomain Function(ClassElement);
 
 /// Auxiliary class used by `classes`. Its `expand` method
 /// expands its argument to a fixed point, based on the `successors` method.
@@ -2506,31 +2506,31 @@ class _AnnotationClassFixedPoint extends FixedPoint<ClassElement> {
   }
 }
 
-final RegExp _identifierRegExp = RegExp(r"^[A-Za-z$_][A-Za-z$_0-9]*$");
+final RegExp _identifierRegExp = RegExp(r'^[A-Za-z$_][A-Za-z$_0-9]*$');
 
 // Auxiliary function used by `_generateCode`.
 String _gettingClosure(String getterName) {
   String closure;
   if (_identifierRegExp.hasMatch(getterName)) {
     // Starts with letter, not an operator.
-    closure = "(dynamic instance) => instance.${getterName}";
-  } else if (getterName == "[]=") {
-    closure = "(dynamic instance) => (x, v) => instance[x] = v";
-  } else if (getterName == "[]") {
-    closure = "(dynamic instance) => (x) => instance[x]";
-  } else if (getterName == "unary-") {
-    closure = "(dynamic instance) => () => -instance";
-  } else if (getterName == "~") {
-    closure = "(dynamic instance) => () => ~instance";
+    closure = '(dynamic instance) => instance.${getterName}';
+  } else if (getterName == '[]=') {
+    closure = '(dynamic instance) => (x, v) => instance[x] = v';
+  } else if (getterName == '[]') {
+    closure = '(dynamic instance) => (x) => instance[x]';
+  } else if (getterName == 'unary-') {
+    closure = '(dynamic instance) => () => -instance';
+  } else if (getterName == '~') {
+    closure = '(dynamic instance) => () => ~instance';
   } else {
-    closure = "(dynamic instance) => (x) => instance ${getterName} x";
+    closure = '(dynamic instance) => (x) => instance ${getterName} x';
   }
   return "r'${getterName}': $closure";
 }
 
 // Auxiliary function used by `_generateCode`.
 String _settingClosure(String setterName) {
-  assert(setterName.substring(setterName.length - 1) == "=");
+  assert(setterName.substring(setterName.length - 1) == '=');
   String name = setterName.substring(0, setterName.length - 1);
   return "r'$setterName': (dynamic instance, value) => instance.$name = value";
 }
@@ -2542,10 +2542,10 @@ Future<String> _staticGettingClosure(_ImportCollector importCollector,
   String prefix = importCollector._getPrefix(classElement.library);
   // Operators cannot be static.
   if (_isPrivateName(getterName)) {
-    await _severe("Cannot access private name $getterName", classElement);
+    await _severe('Cannot access private name $getterName', classElement);
   }
   if (_isPrivateName(className)) {
-    await _severe("Cannot access private name $className", classElement);
+    await _severe('Cannot access private name $className', classElement);
   }
   return "r'${getterName}': () => $prefix$className.$getterName";
 }
@@ -2553,16 +2553,16 @@ Future<String> _staticGettingClosure(_ImportCollector importCollector,
 // Auxiliary function used by `_generateCode`.
 Future<String> _staticSettingClosure(_ImportCollector importCollector,
     ClassElement classElement, String setterName) async {
-  assert(setterName.substring(setterName.length - 1) == "=");
-  // The [setterName] includes the "=", remove it.
+  assert(setterName.substring(setterName.length - 1) == '=');
+  // The [setterName] includes the '=', remove it.
   String name = setterName.substring(0, setterName.length - 1);
   String className = classElement.name;
   String prefix = importCollector._getPrefix(classElement.library);
   if (_isPrivateName(setterName)) {
-    await _severe("Cannot access private name $setterName", classElement);
+    await _severe('Cannot access private name $setterName', classElement);
   }
   if (_isPrivateName(className)) {
-    await _severe("Cannot access private name $className", classElement);
+    await _severe('Cannot access private name $className', classElement);
   }
   return "r'$setterName': (value) => $prefix$className.$name = value";
 }
@@ -2573,7 +2573,7 @@ Future<String> _topLevelGettingClosure(_ImportCollector importCollector,
   String prefix = importCollector._getPrefix(library);
   // Operators cannot be top-level.
   if (_isPrivateName(getterName)) {
-    await _severe("Cannot access private name $getterName", library);
+    await _severe('Cannot access private name $getterName', library);
   }
   return "r'${getterName}': () => $prefix$getterName";
 }
@@ -2581,18 +2581,18 @@ Future<String> _topLevelGettingClosure(_ImportCollector importCollector,
 // Auxiliary function used by `_generateCode`.
 Future<String> _topLevelSettingClosure(_ImportCollector importCollector,
     LibraryElement library, String setterName) async {
-  assert(setterName.substring(setterName.length - 1) == "=");
-  // The [setterName] includes the "=", remove it.
+  assert(setterName.substring(setterName.length - 1) == '=');
+  // The [setterName] includes the '=', remove it.
   String name = setterName.substring(0, setterName.length - 1);
   String prefix = importCollector._getPrefix(library);
   if (_isPrivateName(name)) {
-    await _severe("Cannot access private name $name", library);
+    await _severe('Cannot access private name $name', library);
   }
   return "r'$setterName': (value) => $prefix$name = value";
 }
 
 // Auxiliary function used by `_typeCodeIndex`.
-String _typedefName(int id) => "typedef$id";
+String _typedefName(int id) => 'typedef$id';
 
 /// Information about reflectability for a given library.
 class _LibraryDomain {
@@ -2643,7 +2643,7 @@ class _LibraryDomain {
 
   @override
   String toString() {
-    return "LibraryDomain($_libraryElement)";
+    return 'LibraryDomain($_libraryElement)';
   }
 
   @override
@@ -2717,11 +2717,11 @@ class _ClassDomain {
       List<InterfaceType> mixins = _classElement.mixins;
       ClassElement superclass = _classElement.supertype?.element;
       String superclassName =
-          superclass == null ? "null" : _qualifiedName(superclass);
+          superclass == null ? 'null' : _qualifiedName(superclass);
       StringBuffer name = StringBuffer(superclassName);
       bool firstSeparator = true;
       for (InterfaceType mixin in mixins) {
-        name.write(firstSeparator ? " with " : ", ");
+        name.write(firstSeparator ? ' with ' : ', ');
         name.write(_qualifiedName(mixin.element));
         firstSeparator = false;
       }
@@ -2771,8 +2771,8 @@ class _ClassDomain {
               member.correspondingGetter;
           getterMetadata = correspondingGetter?.metadata;
         }
-        if (_reflectorDomain._capabilities
-            .supportsInstanceInvoke(member.name, metadata, getterMetadata)) {
+        if (_reflectorDomain._capabilities.supportsInstanceInvoke(
+            member.library.typeSystem, member.name, metadata, getterMetadata)) {
           result[name] = member;
         }
       }
@@ -2824,8 +2824,8 @@ class _ClassDomain {
     void possiblyAddMethod(MethodElement method) {
       if (method.isStatic &&
           !method.isPrivate &&
-          _reflectorDomain._capabilities
-              .supportsStaticInvoke(method.name, method.metadata, null)) {
+          _reflectorDomain._capabilities.supportsStaticInvoke(
+              method.library.typeSystem, method.name, method.metadata, null)) {
         result.add(method);
       }
     }
@@ -2844,8 +2844,11 @@ class _ClassDomain {
             accessor.correspondingGetter;
         getterMetadata = correspondingGetter?.metadata;
       }
-      if (_reflectorDomain._capabilities
-          .supportsStaticInvoke(accessor.name, metadata, getterMetadata)) {
+      if (_reflectorDomain._capabilities.supportsStaticInvoke(
+          accessor.library.typeSystem,
+          accessor.name,
+          metadata,
+          getterMetadata)) {
         result.add(accessor);
       }
     }
@@ -2857,14 +2860,14 @@ class _ClassDomain {
 
   @override
   String toString() {
-    return "ClassDomain($_classElement)";
+    return 'ClassDomain($_classElement)';
   }
 }
 
 /// A wrapper around a list of Capabilities.
 /// Supports queries about the methods supported by the set of capabilities.
 class _Capabilities {
-  List<ec.ReflectCapability> _capabilities;
+  final List<ec.ReflectCapability> _capabilities;
   _Capabilities(this._capabilities);
 
   bool _supportsName(ec.NamePatternCapability capability, String methodName) {
@@ -2872,15 +2875,24 @@ class _Capabilities {
     return regexp.hasMatch(methodName);
   }
 
-  bool _supportsMeta(ec.MetadataQuantifiedCapability capability,
+  bool _supportsMeta(
+      TypeSystem typeSystem,
+      ec.MetadataQuantifiedCapability capability,
       Iterable<DartObject> metadata) {
     if (metadata == null) return false;
-    return metadata.map<ParameterizedType>((DartObject o) => o.type).any(
-        (ParameterizedType parameterizedType) =>
-            parameterizedType.isSubtypeOf(capability.metadataType.instantiate()));
+    bool result = false;
+    DartType capabilityType = capability.metadataType.instantiate();
+    for (var metadatum in metadata) {
+      if (typeSystem.isSubtypeOf(metadatum.type, capabilityType)) {
+        result = true;
+        break;
+      }
+    }
+    return result;
   }
 
   bool _supportsInstanceInvoke(
+      TypeSystem typeSystem,
       List<ec.ReflectCapability> capabilities,
       String methodName,
       Iterable<DartObject> metadata,
@@ -2892,7 +2904,7 @@ class _Capabilities {
         return true;
       }
       if (capability is ec.InstanceInvokeMetaCapability &&
-          _supportsMeta(capability, metadata)) {
+          _supportsMeta(typeSystem, capability, metadata)) {
         return true;
       }
       // Quantifying capabilities have no effect on the availability of
@@ -2902,7 +2914,7 @@ class _Capabilities {
 
     // Check if we can retry, using the corresponding getter.
     if (_isSetterName(methodName) && getterMetadata != null) {
-      return _supportsInstanceInvoke(capabilities,
+      return _supportsInstanceInvoke(typeSystem, capabilities,
           _setterNameToGetterName(methodName), getterMetadata, null);
     }
 
@@ -2910,8 +2922,11 @@ class _Capabilities {
     return false;
   }
 
-  bool _supportsNewInstance(Iterable<ec.ReflectCapability> capabilities,
-      String constructorName, Iterable<DartObject> metadata) {
+  bool _supportsNewInstance(
+      TypeSystem typeSystem,
+      Iterable<ec.ReflectCapability> capabilities,
+      String constructorName,
+      Iterable<DartObject> metadata) {
     for (ec.ReflectCapability capability in capabilities) {
       // Handle API based capabilities.
       if ((capability is ec.InvokingCapability ||
@@ -2921,7 +2936,7 @@ class _Capabilities {
       }
       if ((capability is ec.InvokingMetaCapability ||
               capability is ec.NewInstanceMetaCapability) &&
-          _supportsMeta(capability, metadata)) {
+          _supportsMeta(typeSystem, capability, metadata)) {
         return true;
       }
       // Quantifying capabilities have no effect on the availability of
@@ -2936,10 +2951,12 @@ class _Capabilities {
   // TODO(sigurdm) future: Find a way to cache these. Perhaps take an
   // element instead of name+metadata.
   bool supportsInstanceInvoke(
+      TypeSystem typeSystem,
       String methodName,
       Iterable<ElementAnnotation> metadata,
       Iterable<ElementAnnotation> getterMetadata) {
     return _supportsInstanceInvoke(
+        typeSystem,
         _capabilities,
         methodName,
         _getEvaluatedMetadata(metadata),
@@ -2947,15 +2964,17 @@ class _Capabilities {
   }
 
   bool supportsNewInstance(
+      TypeSystem typeSystem,
       String constructorName,
       Iterable<ElementAnnotation> metadata,
       LibraryElement libraryElement,
       Resolver resolver) {
-    return _supportsNewInstance(
-        _capabilities, constructorName, _getEvaluatedMetadata(metadata));
+    return _supportsNewInstance(typeSystem, _capabilities, constructorName,
+        _getEvaluatedMetadata(metadata));
   }
 
   bool _supportsTopLevelInvoke(
+      TypeSystem typeSystem,
       List<ec.ReflectCapability> capabilities,
       String methodName,
       Iterable<DartObject> metadata,
@@ -2967,7 +2986,7 @@ class _Capabilities {
         return true;
       }
       if ((capability is ec.TopLevelInvokeMetaCapability) &&
-          _supportsMeta(capability, metadata)) {
+          _supportsMeta(typeSystem, capability, metadata)) {
         return true;
       }
       // Quantifying capabilities do not influence the availability
@@ -2976,7 +2995,7 @@ class _Capabilities {
 
     // Check if we can retry, using the corresponding getter.
     if (_isSetterName(methodName) && getterMetadata != null) {
-      return _supportsTopLevelInvoke(capabilities,
+      return _supportsTopLevelInvoke(typeSystem, capabilities,
           _setterNameToGetterName(methodName), getterMetadata, null);
     }
 
@@ -2985,6 +3004,7 @@ class _Capabilities {
   }
 
   bool _supportsStaticInvoke(
+      TypeSystem typeSystem,
       List<ec.ReflectCapability> capabilities,
       String methodName,
       Iterable<DartObject> metadata,
@@ -2996,7 +3016,7 @@ class _Capabilities {
         return true;
       }
       if (capability is ec.StaticInvokeMetaCapability &&
-          _supportsMeta(capability, metadata)) {
+          _supportsMeta(typeSystem, capability, metadata)) {
         return true;
       }
       // Quantifying capabilities have no effect on the availability of
@@ -3006,7 +3026,7 @@ class _Capabilities {
 
     // Check if we can retry, using the corresponding getter.
     if (_isSetterName(methodName) && getterMetadata != null) {
-      return _supportsStaticInvoke(capabilities,
+      return _supportsStaticInvoke(typeSystem, capabilities,
           _setterNameToGetterName(methodName), getterMetadata, null);
     }
 
@@ -3015,10 +3035,12 @@ class _Capabilities {
   }
 
   bool supportsTopLevelInvoke(
+      TypeSystem typeSystem,
       String methodName,
       Iterable<ElementAnnotation> metadata,
       Iterable<ElementAnnotation> getterMetadata) {
     return _supportsTopLevelInvoke(
+        typeSystem,
         _capabilities,
         methodName,
         _getEvaluatedMetadata(metadata),
@@ -3026,10 +3048,12 @@ class _Capabilities {
   }
 
   bool supportsStaticInvoke(
+      TypeSystem typeSystem,
       String methodName,
       Iterable<ElementAnnotation> metadata,
       Iterable<ElementAnnotation> getterMetadata) {
     return _supportsStaticInvoke(
+        typeSystem,
         _capabilities,
         methodName,
         _getEvaluatedMetadata(metadata),
@@ -3105,8 +3129,8 @@ class _Capabilities {
         if (element is ClassElement) {
           result[element] = capability.excludeUpperBound;
         } else {
-          await _severe("Unexpected kind of upper bound specified "
-              "for a `SuperclassQuantifyCapability`: $element.");
+          await _severe('Unexpected kind of upper bound specified '
+              'for a `SuperclassQuantifyCapability`: $element.');
         }
       }
     }
@@ -3181,16 +3205,16 @@ class _Capabilities {
 /// Collects the libraries that needs to be imported, and gives each library
 /// a unique prefix.
 class _ImportCollector {
-  Map<LibraryElement, String> _mapping = <LibraryElement, String>{};
+  final _mapping = <LibraryElement, String>{};
   int _count = 0;
 
   /// Returns the prefix associated with [library]. Iff it is non-empty
   /// it includes the period.
   String _getPrefix(LibraryElement library) {
-    if (library.isDartCore) return "";
+    if (library.isDartCore) return '';
     String prefix = _mapping[library];
     if (prefix != null) return prefix;
-    prefix = "prefix$_count.";
+    prefix = 'prefix$_count.';
     _count++;
     _mapping[library] = prefix;
     return prefix;
@@ -3202,7 +3226,7 @@ class _ImportCollector {
     if (library.isDartCore) return;
     String prefix = _mapping[library];
     if (prefix != null) return;
-    prefix = "prefix$_count.";
+    prefix = 'prefix$_count.';
     _count++;
     _mapping[library] = prefix;
   }
@@ -3228,13 +3252,13 @@ class _ImportCollector {
 /// Keeps track of the number of entry points seen. Used to determine when the
 /// transformation job is complete during `pub build..` or stand-alone
 /// transformation, such that it is time to give control to the debugger.
-/// Only in use when `const bool.fromEnvironment("reflectable.pause.at.exit")`.
+/// Only in use when `const bool.fromEnvironment('reflectable.pause.at.exit')`.
 int _processedEntryPointCount = 0;
 
 class BuilderImplementation {
   Resolver _resolver;
-  List<LibraryElement> _libraries = [];
-  Map<String, LibraryElement> _librariesByName = {};
+  var _libraries = <LibraryElement>[];
+  final _librariesByName = <String, LibraryElement>{};
   bool _formatted;
   List<WarningKind> _suppressedWarnings;
 
@@ -3266,7 +3290,7 @@ class BuilderImplementation {
   /// reflectable.dart.  So we use [Reflectable.thisClassId] which is very
   /// unlikely to occur with the same value elsewhere by accident.
   bool _equalsClassReflectable(ClassElement type) {
-    FieldElement idField = type.getField("thisClassId");
+    FieldElement idField = type.getField('thisClassId');
     if (idField == null || !idField.isStatic) return false;
     if (idField is VariableElement) {
       DartObject constantValue = idField.computeConstantValue();
@@ -3370,19 +3394,19 @@ class BuilderImplementation {
         // would mean that the value is actually null, which we will also
         // reject as irrelevant.
         if (constantValue == null) return null;
-        bool isOk =
-            await checkInheritance(constantValue.type, focusClass.instantiate());
+        bool isOk = await checkInheritance(
+            constantValue.type, focusClass.instantiate());
         // When `isOK` is true, result.value.type.element is a ClassElement.
         return isOk ? constantValue.type.element : null;
       } else {
-        await _fine("Ignoring unsupported metadata form ${element}", element);
+        await _fine('Ignoring unsupported metadata form ${element}', element);
         return null;
       }
     }
     // Otherwise [element] is some other construct which is not supported.
     await _fine(
-        "Ignoring metadata in a form ($elementAnnotation) "
-        "which is not yet supported.",
+        'Ignoring metadata in a form ($elementAnnotation) '
+        'which is not yet supported.',
         elementAnnotation.element);
     return null;
   }
@@ -3406,19 +3430,19 @@ class BuilderImplementation {
       Map<RegExp, List<ClassElement>> globalPatterns,
       Map<ClassElement, List<ClassElement>> globalMetadata) async {
     LibraryElement reflectableLibrary =
-        _librariesByName["reflectable.reflectable"];
+        _librariesByName['reflectable.reflectable'];
     LibraryElement capabilityLibrary =
-        _librariesByName["reflectable.capability"];
-    ClassElement reflectableClass = reflectableLibrary.getType("Reflectable");
+        _librariesByName['reflectable.capability'];
+    ClassElement reflectableClass = reflectableLibrary.getType('Reflectable');
     ClassElement typeClass = reflectableLibrary.typeProvider.typeType.element;
 
     ConstructorElement globalQuantifyCapabilityConstructor = capabilityLibrary
-        .getType("GlobalQuantifyCapability")
-        .getNamedConstructor("");
+        .getType('GlobalQuantifyCapability')
+        .getNamedConstructor('');
     ConstructorElement globalQuantifyMetaCapabilityConstructor =
         capabilityLibrary
-            .getType("GlobalQuantifyMetaCapability")
-            .getNamedConstructor("");
+            .getType('GlobalQuantifyMetaCapability')
+            .getNamedConstructor('');
 
     for (LibraryElement library in _libraries) {
       for (ImportElement import in library.imports) {
@@ -3428,22 +3452,22 @@ class BuilderImplementation {
             DartObject value = _getEvaluatedMetadatum(metadatum);
             if (value != null) {
               String pattern =
-                  value.getField("classNamePattern").toStringValue();
+                  value.getField('classNamePattern').toStringValue();
               if (pattern == null) {
                 await _warn(WarningKind.badNamePattern,
-                    "The classNamePattern must be a string", metadatum.element);
+                    'The classNamePattern must be a string', metadatum.element);
                 continue;
               }
               ClassElement reflector =
-                  value.getField("(super)").getField("reflector").type.element;
+                  value.getField('(super)').getField('reflector').type.element;
               if (reflector == null ||
                   reflector.instantiate().element.supertype.element !=
                       reflectableClass) {
                 String found =
-                    reflector == null ? "" : " Found ${reflector.name}";
+                    reflector == null ? '' : ' Found ${reflector.name}';
                 await _warn(
                     WarningKind.badSuperclass,
-                    "The reflector must be a direct subclass of Reflectable." +
+                    'The reflector must be a direct subclass of Reflectable.' +
                         found,
                     metadatum.element);
                 continue;
@@ -3457,30 +3481,30 @@ class BuilderImplementation {
             DartObject constantValue = metadatum.computeConstantValue();
             if (constantValue != null) {
               Object metadataFieldValue =
-                  constantValue.getField("metadataType").toTypeValue().element;
+                  constantValue.getField('metadataType').toTypeValue().element;
               if (metadataFieldValue == null ||
-                  constantValue.getField("metadataType").type.element !=
+                  constantValue.getField('metadataType').type.element !=
                       typeClass) {
                 await _warn(
                     WarningKind.badMetadata,
-                    "The metadata must be a Type. "
-                    "Found ${constantValue.getField("metadataType").type.element.name}",
+                    'The metadata must be a Type. '
+                    'Found ${constantValue.getField('metadataType').type.element.name}',
                     metadatum.element);
                 continue;
               }
               ClassElement reflector = constantValue
-                  .getField("(super)")
-                  .getField("reflector")
+                  .getField('(super)')
+                  .getField('reflector')
                   .type
                   .element;
               if (reflector == null ||
                   reflector.instantiate().element.supertype.element !=
                       reflectableClass) {
                 String found =
-                    reflector == null ? "" : " Found ${reflector.name}";
+                    reflector == null ? '' : ' Found ${reflector.name}';
                 await _warn(
                     WarningKind.badSuperclass,
-                    "The reflector must be a direct subclass of Reflectable." +
+                    'The reflector must be a direct subclass of Reflectable.' +
                         found,
                     metadatum.element);
                 continue;
@@ -3495,11 +3519,11 @@ class BuilderImplementation {
                 // order to cover _everything_ that has an annotation at all,
                 // and maybe other things like function types as metadata.
                 var typeName =
-                    constantValue.getField("metadataType").type.element.name;
+                    constantValue.getField('metadataType').type.element.name;
                 await _warn(
                     WarningKind.badMetadata,
-                    "The metadata must be a class type. "
-                    "Found $typeName",
+                    'The metadata must be a class type. '
+                    'Found $typeName',
                     metadatum.element);
                 continue;
               }
@@ -3521,7 +3545,8 @@ class BuilderImplementation {
   Future<bool> _isReflectorClass(ClassElement potentialReflectorClass,
       ClassElement reflectableClass) async {
     if (potentialReflectorClass == reflectableClass) return false;
-    InterfaceType potentialReflectorType = potentialReflectorClass.instantiate();
+    InterfaceType potentialReflectorType =
+        potentialReflectorClass.instantiate();
     InterfaceType reflectableType = reflectableClass.instantiate();
     if (!_isSubclassOf(potentialReflectorType, reflectableType)) {
       // Not a subclass of [classReflectable] at all.
@@ -3534,19 +3559,19 @@ class BuilderImplementation {
       // at all, even though we don't know for sure it is used as a reflector.
       await _warn(
           WarningKind.badReflectorClass,
-          "An indirect subclass of `Reflectable` will not work as a reflector."
-          "\nIt is not recommended to have such a class at all.",
+          'An indirect subclass of `Reflectable` will not work as a reflector.'
+          '\nIt is not recommended to have such a class at all.',
           potentialReflectorClass);
       return false;
     }
 
     Future<void> constructorFail() async {
       await _severe(
-          "A reflector class must have exactly one "
-          "constructor which is `const`, has \n"
-          "the empty name, takes zero arguments, and "
-          "uses at most one superinitializer.\n"
-          "Please correct `$potentialReflectorClass` to match this.",
+          'A reflector class must have exactly one '
+          'constructor which is `const`, has \n'
+          'the empty name, takes zero arguments, and '
+          'uses at most one superinitializer.\n'
+          'Please correct `$potentialReflectorClass` to match this.',
           potentialReflectorClass);
     }
 
@@ -3595,32 +3620,29 @@ class BuilderImplementation {
       LibraryElement entryPoint, AssetId dataId) async {
     final ClassElement classReflectable =
         await _findReflectableClassElement(reflectableLibrary);
-    final Set<ClassElement> allReflectors = Set<ClassElement>();
+    final allReflectors = <ClassElement>{};
 
     // If class `Reflectable` is absent the transformation must be a no-op.
     if (classReflectable == null) {
-      log.info("Ignoring entry point $entryPoint that does not "
-          "include the class `Reflectable`.");
+      log.info('Ignoring entry point $entryPoint that does not '
+          'include the class `Reflectable`.');
       return null;
     }
 
     // The world will be built from the library arguments plus these two.
-    final Map<ClassElement, _ReflectorDomain> domains =
-        <ClassElement, _ReflectorDomain>{};
-    final _ImportCollector importCollector = _ImportCollector();
+    final domains = <ClassElement, _ReflectorDomain>{};
+    final importCollector = _ImportCollector();
 
     // Maps each pattern to the list of reflectors associated with it via
     // a [GlobalQuantifyCapability].
-    Map<RegExp, List<ClassElement>> globalPatterns =
-        <RegExp, List<ClassElement>>{};
+    var globalPatterns = <RegExp, List<ClassElement>>{};
 
     // Maps each [Type] to the list of reflectors associated with it via
     // a [GlobalQuantifyMetaCapability].
-    Map<ClassElement, List<ClassElement>> globalMetadata =
-        Map<ClassElement, List<ClassElement>>();
+    var globalMetadata = <ClassElement, List<ClassElement>>{};
 
     final LibraryElement capabilityLibrary =
-        _librariesByName["reflectable.capability"];
+        _librariesByName['reflectable.capability'];
 
     /// Gets the [ReflectorDomain] associated with [reflector], or creates
     /// it if none exists.
@@ -3655,7 +3677,7 @@ class BuilderImplementation {
     Future<void> addClassDomain(
         ClassElement type, ClassElement reflector) async {
       if (!await _isImportable(type, dataId, _resolver)) {
-        await _fine("Ignoring unrepresentable class ${type.name}", type);
+        await _fine('Ignoring unrepresentable class ${type.name}', type);
       } else {
         _ReflectorDomain domain = await getReflectorDomain(reflector);
         if (!domain._classes.contains(type)) {
@@ -3776,13 +3798,13 @@ class BuilderImplementation {
       }
     }
 
-    Set<ClassElement> usedReflectors = Set<ClassElement>();
-    for (_ReflectorDomain domain in domains.values) {
+    var usedReflectors = <ClassElement>{};
+    for (var domain in domains.values) {
       usedReflectors.add(domain._reflector);
     }
     for (ClassElement reflector in allReflectors.difference(usedReflectors)) {
       await _warn(WarningKind.unusedReflector,
-          "This reflector does not match anything", reflector);
+          'This reflector does not match anything', reflector);
       // Ensure that there is an empty domain for `reflector` in `domains`.
       await getReflectorDomain(reflector);
     }
@@ -3815,7 +3837,7 @@ class BuilderImplementation {
 
     if (evaluated == null || !evaluated.isValid) {
       await _severe(
-          "Invalid constant `$expression` in capability list.", messageTarget);
+          'Invalid constant `$expression` in capability list.', messageTarget);
       // We do not terminate immediately at `_severe` so we need to
       // return something that will not generate too much noise for the
       // receiver.
@@ -3827,7 +3849,7 @@ class BuilderImplementation {
     if (constant == null) {
       // This could be because it is an argument to a `const` constructor,
       // but we do not support that.
-      await _severe("Unsupported constant `$expression` in capability list.",
+      await _severe('Unsupported constant `$expression` in capability list.',
           messageTarget);
       return ec.invokingCapability; // Error default.
     }
@@ -3840,7 +3862,7 @@ class BuilderImplementation {
     if (dartType.element is! ClassElement) {
       await _severe(
           errors.applyTemplate(
-              errors.SUPER_ARGUMENT_NON_CLASS, {"type": dartType.displayName}),
+              errors.SUPER_ARGUMENT_NON_CLASS, {'type': dartType.displayName}),
           dartType.element);
       return ec.invokingCapability; // Error default.
     }
@@ -3848,7 +3870,7 @@ class BuilderImplementation {
     if (classElement.library != capabilityLibrary) {
       await _severe(
           errors.applyTemplate(errors.SUPER_ARGUMENT_WRONG_LIBRARY,
-              {"library": "$capabilityLibrary", "element": "$classElement"}),
+              {'library': '$capabilityLibrary', 'element': '$classElement'}),
           classElement);
       return ec.invokingCapability; // Error default.
     }
@@ -3856,20 +3878,20 @@ class BuilderImplementation {
     /// Extracts the namePattern String from an instance of a subclass of
     /// NamePatternCapability.
     Future<String> extractNamePattern(DartObject constant) async {
-      if (constant.getField("(super)") == null ||
-          constant.getField("(super)").getField("namePattern") == null ||
+      if (constant.getField('(super)') == null ||
+          constant.getField('(super)').getField('namePattern') == null ||
           constant
-                  .getField("(super)")
-                  .getField("namePattern")
+                  .getField('(super)')
+                  .getField('namePattern')
                   .toStringValue() ==
               null) {
         await _warn(WarningKind.badNamePattern,
-            "Could not extract namePattern from capability.", messageTarget);
-        return "";
+            'Could not extract namePattern from capability.', messageTarget);
+        return '';
       }
       return constant
-          .getField("(super)")
-          .getField("namePattern")
+          .getField('(super)')
+          .getField('namePattern')
           .toStringValue();
     }
 
@@ -3877,86 +3899,86 @@ class BuilderImplementation {
     /// MetadataCapability represented by [constant], reporting any diagnostic
     /// messages as referring to [messageTarget].
     Future<ClassElement> extractMetaData(DartObject constant) async {
-      if (constant.getField("(super)") == null ||
-          constant.getField("(super)").getField("metadataType") == null) {
+      if (constant.getField('(super)') == null ||
+          constant.getField('(super)').getField('metadataType') == null) {
         await _warn(WarningKind.badMetadata,
-            "Could not extract metadata type from capability.", messageTarget);
+            'Could not extract metadata type from capability.', messageTarget);
         return null;
       }
       Object metadataFieldValue = constant
-          .getField("(super)")
-          .getField("metadataType")
+          .getField('(super)')
+          .getField('metadataType')
           .toTypeValue()
           .element;
       if (metadataFieldValue is ClassElement) return metadataFieldValue;
       await _warn(
           WarningKind.badMetadata,
-          "Metadata specification in capability must be a `Type`.",
+          'Metadata specification in capability must be a `Type`.',
           messageTarget);
       return null;
     }
 
     switch (classElement.name) {
-      case "NameCapability":
+      case 'NameCapability':
         return ec.nameCapability;
-      case "ClassifyCapability":
+      case 'ClassifyCapability':
         return ec.classifyCapability;
-      case "MetadataCapability":
+      case 'MetadataCapability':
         return ec.metadataCapability;
-      case "TypeRelationsCapability":
+      case 'TypeRelationsCapability':
         return ec.typeRelationsCapability;
-      case "_ReflectedTypeCapability":
+      case '_ReflectedTypeCapability':
         return ec.reflectedTypeCapability;
-      case "LibraryCapability":
+      case 'LibraryCapability':
         return ec.libraryCapability;
-      case "DeclarationsCapability":
+      case 'DeclarationsCapability':
         return ec.declarationsCapability;
-      case "UriCapability":
+      case 'UriCapability':
         return ec.uriCapability;
-      case "LibraryDependenciesCapability":
+      case 'LibraryDependenciesCapability':
         return ec.libraryDependenciesCapability;
-      case "InstanceInvokeCapability":
+      case 'InstanceInvokeCapability':
         return ec.InstanceInvokeCapability(await extractNamePattern(constant));
-      case "InstanceInvokeMetaCapability":
+      case 'InstanceInvokeMetaCapability':
         return ec.InstanceInvokeMetaCapability(await extractMetaData(constant));
-      case "StaticInvokeCapability":
+      case 'StaticInvokeCapability':
         return ec.StaticInvokeCapability(await extractNamePattern(constant));
-      case "StaticInvokeMetaCapability":
+      case 'StaticInvokeMetaCapability':
         return ec.StaticInvokeMetaCapability(await extractMetaData(constant));
-      case "TopLevelInvokeCapability":
+      case 'TopLevelInvokeCapability':
         return ec.TopLevelInvokeCapability(await extractNamePattern(constant));
-      case "TopLevelInvokeMetaCapability":
+      case 'TopLevelInvokeMetaCapability':
         return ec.TopLevelInvokeMetaCapability(await extractMetaData(constant));
-      case "NewInstanceCapability":
+      case 'NewInstanceCapability':
         return ec.NewInstanceCapability(await extractNamePattern(constant));
-      case "NewInstanceMetaCapability":
+      case 'NewInstanceMetaCapability':
         return ec.NewInstanceMetaCapability(await extractMetaData(constant));
-      case "TypeCapability":
+      case 'TypeCapability':
         return ec.TypeCapability();
-      case "InvokingCapability":
+      case 'InvokingCapability':
         return ec.InvokingCapability(await extractNamePattern(constant));
-      case "InvokingMetaCapability":
+      case 'InvokingMetaCapability':
         return ec.InvokingMetaCapability(await extractMetaData(constant));
-      case "TypingCapability":
+      case 'TypingCapability':
         return ec.TypingCapability();
-      case "_DelegateCapability":
+      case '_DelegateCapability':
         return ec.delegateCapability;
-      case "_SubtypeQuantifyCapability":
+      case '_SubtypeQuantifyCapability':
         return ec.subtypeQuantifyCapability;
-      case "SuperclassQuantifyCapability":
+      case 'SuperclassQuantifyCapability':
         return ec.SuperclassQuantifyCapability(
-            constant.getField("upperBound").toTypeValue().element,
+            constant.getField('upperBound').toTypeValue().element,
             excludeUpperBound:
-                constant.getField("excludeUpperBound").toBoolValue());
-      case "TypeAnnotationQuantifyCapability":
+                constant.getField('excludeUpperBound').toBoolValue());
+      case 'TypeAnnotationQuantifyCapability':
         return ec.TypeAnnotationQuantifyCapability(
-            transitive: constant.getField("transitive").toBoolValue());
-      case "_CorrespondingSetterQuantifyCapability":
+            transitive: constant.getField('transitive').toBoolValue());
+      case '_CorrespondingSetterQuantifyCapability':
         return ec.correspondingSetterQuantifyCapability;
-      case "_AdmitSubtypeCapability":
+      case '_AdmitSubtypeCapability':
         // TODO(eernst) implement: support for the admit subtype feature.
         await _severe(
-            "_AdmitSubtypeCapability not yet supported!", messageTarget);
+            '_AdmitSubtypeCapability not yet supported!', messageTarget);
         return ec.admitSubtypeCapability;
       default:
         // We have checked that [element] is declared in 'capability.dart',
@@ -3964,7 +3986,7 @@ class BuilderImplementation {
         // superinitializer of a const constructor, and we have tested
         // for all classes in that library which can provide a const value,
         // so we should not reach this point.
-        await _severe("Unexpected capability $classElement");
+        await _severe('Unexpected capability $classElement');
         return ec.invokingCapability; // Error default.
     }
   }
@@ -4023,9 +4045,9 @@ class BuilderImplementation {
       if (collectionElement is Expression) {
         return await capabilityOfExpression(collectionElement);
       } else {
-        await _severe("Not yet supported! "
-            "Encountered a collection element which is not an expression: "
-            "$collectionElement");
+        await _severe('Not yet supported! '
+            'Encountered a collection element which is not an expression: '
+            '$collectionElement');
         return null;
       }
     }
@@ -4039,7 +4061,7 @@ class BuilderImplementation {
       }
       return _Capabilities(capabilities);
     }
-    assert(superInvocation.constructorName.name == "fromList");
+    assert(superInvocation.constructorName.name == 'fromList');
 
     // Subcase: `super.fromList(const <..>[..])`.
     NodeList<Expression> arguments = superInvocation.argumentList.arguments;
@@ -4075,7 +4097,7 @@ class BuilderImplementation {
     }
     imports.sort();
 
-    String result = """
+    String result = '''
 // This file has been generated by the reflectable package.
 // https://github.com/dart-lang/reflectable.
 
@@ -4099,7 +4121,7 @@ void initializeReflectable() {
   r.data = _data;
   r.memberSymbolMap = _memberSymbolMap;
 }
-""";
+''';
     if (_formatted) {
       DartFormatter formatter = DartFormatter();
       result = formatter.format(result);
@@ -4128,21 +4150,21 @@ void initializeReflectable() {
       if (library.name != null) _librariesByName[library.name] = library;
     }
     LibraryElement reflectableLibrary =
-        _librariesByName["reflectable.reflectable"];
+        _librariesByName['reflectable.reflectable'];
 
     if (reflectableLibrary == null) {
       // Stop and let the original source pass through without changes.
-      log.info("Ignoring entry point $inputId that does not "
+      log.info('Ignoring entry point $inputId that does not '
           "include the library 'package:reflectable/reflectable.dart'");
-      if (const bool.fromEnvironment("reflectable.pause.at.exit")) {
+      if (const bool.fromEnvironment('reflectable.pause.at.exit')) {
         _processedEntryPointCount++;
       }
-      return "// No output from reflectable, "
+      return '// No output from reflectable, '
           "'package:reflectable/reflectable.dart' not used.";
     } else {
       reflectableLibrary = await _resolvedLibraryOf(reflectableLibrary);
 
-      if (const bool.fromEnvironment("reflectable.print.entry.point")) {
+      if (const bool.fromEnvironment('reflectable.print.entry.point')) {
         print("Starting build for '$inputId'.");
       }
 
@@ -4150,27 +4172,27 @@ void initializeReflectable() {
           await _computeWorld(reflectableLibrary, inputLibrary, inputId);
       if (world == null) {
         // Errors have already been reported during `_computeWorld`.
-        if (const bool.fromEnvironment("reflectable.pause.at.exit")) {
+        if (const bool.fromEnvironment('reflectable.pause.at.exit')) {
           _processedEntryPointCount++;
         }
-        return "// No output from reflectable, stopped with error.";
+        return '// No output from reflectable, stopped with error.';
       } else {
         if (inputLibrary.entryPoint == null) {
-          log.info("Entry point: $inputId has no `main`. Skipping.");
-          if (const bool.fromEnvironment("reflectable.pause.at.exit")) {
+          log.info('Entry point: $inputId has no `main`. Skipping.');
+          if (const bool.fromEnvironment('reflectable.pause.at.exit')) {
             _processedEntryPointCount++;
           }
-          return "// No output from reflectable, there is no `main`.";
+          return '// No output from reflectable, there is no `main`.';
         } else {
           String outputContents = await _generateNewEntryPoint(
               world, generatedLibraryId, path.basename(inputId.path));
-          if (const bool.fromEnvironment("reflectable.pause.at.exit")) {
+          if (const bool.fromEnvironment('reflectable.pause.at.exit')) {
             _processedEntryPointCount++;
           }
-          if (const bool.fromEnvironment("reflectable.pause.at.exit")) {
+          if (const bool.fromEnvironment('reflectable.pause.at.exit')) {
             if (_processedEntryPointCount ==
-                const int.fromEnvironment("reflectable.pause.at.exit.count")) {
-              print("Build complete, pausing at exit.");
+                const int.fromEnvironment('reflectable.pause.at.exit.count')) {
+              print('Build complete, pausing at exit.');
               developer.debugger();
             }
           }
@@ -4189,7 +4211,7 @@ void initializeReflectable() {
       }
     }
     // This can occur when the library is not used.
-    await _fine("Could not resolve library $libraryElement");
+    await _fine('Could not resolve library $libraryElement');
     return libraryElement;
   }
 }
@@ -4360,26 +4382,26 @@ int _declarationDescriptor(ExecutableElement element) {
 }
 
 Future<String> _nameOfConstructor(ConstructorElement element) async {
-  String name = element.name == ""
+  String name = element.name == ''
       ? element.enclosingElement.name
-      : "${element.enclosingElement.name}.${element.name}";
+      : '${element.enclosingElement.name}.${element.name}';
   if (_isPrivateName(name)) {
-    await _severe("Cannot access private name $name", element);
+    await _severe('Cannot access private name $name', element);
   }
   return name;
 }
 
 String _formatAsList(String typeName, Iterable parts) =>
-    "<${typeName}>[${parts.join(", ")}]";
+    '<${typeName}>[${parts.join(', ')}]';
 
 String _formatAsConstList(String typeName, Iterable parts) =>
-    "const <${typeName}>[${parts.join(", ")}]";
+    'const <${typeName}>[${parts.join(', ')}]';
 
-String _formatAsDynamicList(Iterable parts) => "[${parts.join(", ")}]";
+String _formatAsDynamicList(Iterable parts) => '[${parts.join(', ')}]';
 
-String _formatAsDynamicSet(Iterable parts) => "{${parts.join(", ")}}";
+String _formatAsDynamicSet(Iterable parts) => '{${parts.join(', ')}}';
 
-String _formatAsMap(Iterable parts) => "{${parts.join(", ")}}";
+String _formatAsMap(Iterable parts) => '{${parts.join(', ')}}';
 
 /// Returns a [String] containing code that will evaluate to the same
 /// value when evaluated in the generated file as the given [expression]
@@ -4392,7 +4414,7 @@ Future<String> _extractConstantCode(
   String typeAnnotationHelper(TypeAnnotation typeName) {
     LibraryElement library = typeName.type.element.library;
     String prefix = importCollector._getPrefix(library);
-    return "$prefix$typeName";
+    return '$prefix$typeName';
   }
 
   Future<String> helper(Expression expression) async {
@@ -4404,20 +4426,20 @@ Future<String> _extractConstantCode(
           elements.add(await helper(subExpression));
         } else {
           // TODO(eernst) implement: `if` and `spread` elements of list.
-          await _severe("Not yet supported! "
-              "Encountered list literal element which is not an expression: "
-              "$collectionElement");
-          elements.add("");
+          await _severe('Not yet supported! '
+              'Encountered list literal element which is not an expression: '
+              '$collectionElement');
+          elements.add('');
         }
       }
       if (expression.typeArguments == null ||
           expression.typeArguments.arguments.isEmpty) {
-        return "const ${_formatAsDynamicList(elements)}";
+        return 'const ${_formatAsDynamicList(elements)}';
       } else {
         assert(expression.typeArguments.arguments.length == 1);
         String typeArgument =
             typeAnnotationHelper(expression.typeArguments.arguments[0]);
-        return "const <$typeArgument>${_formatAsDynamicList(elements)}";
+        return 'const <$typeArgument>${_formatAsDynamicList(elements)}';
       }
     } else if (expression is SetOrMapLiteral) {
       if (expression.isMap) {
@@ -4426,25 +4448,25 @@ Future<String> _extractConstantCode(
           if (collectionElement is MapLiteralEntry) {
             String key = await helper(collectionElement.key);
             String value = await helper(collectionElement.value);
-            elements.add("$key: $value");
+            elements.add('$key: $value');
           } else {
             // TODO(eernst) implement: `if` and `spread` elements of a map.
-            await _severe("Not yet supported! "
-                "Encountered map literal element which is not a map entry: "
-                "$collectionElement");
-            elements.add("");
+            await _severe('Not yet supported! '
+                'Encountered map literal element which is not a map entry: '
+                '$collectionElement');
+            elements.add('');
           }
         }
         if (expression.typeArguments == null ||
             expression.typeArguments.arguments.isEmpty) {
-          return "const ${_formatAsMap(elements)}";
+          return 'const ${_formatAsMap(elements)}';
         } else {
           assert(expression.typeArguments.arguments.length == 2);
           String keyType =
               typeAnnotationHelper(expression.typeArguments.arguments[0]);
           String valueType =
               typeAnnotationHelper(expression.typeArguments.arguments[1]);
-          return "const <$keyType, $valueType>${_formatAsMap(elements)}";
+          return 'const <$keyType, $valueType>${_formatAsMap(elements)}';
         }
       } else if (expression.isSet) {
         List<String> elements = [];
@@ -4454,31 +4476,31 @@ Future<String> _extractConstantCode(
             elements.add(await helper(subExpression));
           } else {
             // TODO(eernst) implement: `if` and `spread` elements of a set.
-            await _severe("Not yet supported! "
-                "Encountered set literal element which is not an expression: "
-                "$collectionElement");
-            elements.add("");
+            await _severe('Not yet supported! '
+                'Encountered set literal element which is not an expression: '
+                '$collectionElement');
+            elements.add('');
           }
         }
         if (expression.typeArguments == null ||
             expression.typeArguments.arguments.isEmpty) {
-          return "const ${_formatAsDynamicSet(elements)}";
+          return 'const ${_formatAsDynamicSet(elements)}';
         } else {
           assert(expression.typeArguments.arguments.length == 1);
           String typeArgument =
               typeAnnotationHelper(expression.typeArguments.arguments[0]);
-          return "const <$typeArgument>${_formatAsDynamicSet(elements)}";
+          return 'const <$typeArgument>${_formatAsDynamicSet(elements)}';
         }
       } else {
-        unreachableError("SetOrMapLiteral is neither a set nor a map");
-        return "";
+        unreachableError('SetOrMapLiteral is neither a set nor a map');
+        return '';
       }
     } else if (expression is InstanceCreationExpression) {
       String constructor = expression.constructorName.toSource();
       if (_isPrivateName(constructor)) {
-        await _severe("Cannot access private name $constructor, "
-            "needed for expression $expression");
-        return "";
+        await _severe('Cannot access private name $constructor, '
+            'needed for expression $expression');
+        return '';
       }
       LibraryElement libraryOfConstructor = expression.staticElement.library;
       if (await _isImportableLibrary(
@@ -4490,18 +4512,18 @@ Future<String> _extractConstantCode(
         for (Expression argument in expression.argumentList.arguments) {
           argumentList.add(await helper(argument));
         }
-        String arguments = argumentList.join(", ");
+        String arguments = argumentList.join(', ');
         // TODO(sigurdm) feature: Type arguments.
         if (_isPrivateName(constructor)) {
-          await _severe("Cannot access private name $constructor, "
-              "needed for expression $expression");
-          return "";
+          await _severe('Cannot access private name $constructor, '
+              'needed for expression $expression');
+          return '';
         }
-        return "const $prefix$constructor($arguments)";
+        return 'const $prefix$constructor($arguments)';
       } else {
-        await _severe("Cannot access library $libraryOfConstructor, "
-            "needed for expression $expression");
-        return "";
+        await _severe('Cannot access library $libraryOfConstructor, '
+            'needed for expression $expression');
+        return '';
       }
     } else if (expression is Identifier) {
       if (Identifier.isPrivateName(expression.name)) {
@@ -4512,74 +4534,74 @@ Future<String> _extractConstantCode(
               .getResolvedLibraryByElement(variable.library);
           var declaration = resolvedLibrary.getElementDeclaration(variable);
           if (declaration == null || declaration.node == null) {
-            await _severe("Cannot handle private identifier $expression");
-            return "";
+            await _severe('Cannot handle private identifier $expression');
+            return '';
           }
           VariableDeclaration variableDeclaration = declaration.node;
           return await helper(variableDeclaration.initializer);
         } else {
-          await _severe("Cannot handle private identifier $expression");
-          return "";
+          await _severe('Cannot handle private identifier $expression');
+          return '';
         }
       } else {
         Element element = expression.staticElement;
         if (element == null) {
           // TODO(eernst): This can occur; but how could `expression` be
           // unresolved? Issue 173.
-          await _fine("Encountered unresolved identifier $expression"
-              " in constant; using null");
-          return "null";
+          await _fine('Encountered unresolved identifier $expression'
+              ' in constant; using null');
+          return 'null';
         } else if (element.library == null) {
-          return "${element.name}";
+          return '${element.name}';
         } else if (await _isImportableLibrary(
             element.library, generatedLibraryId, resolver)) {
           importCollector._addLibrary(element.library);
           String prefix = importCollector._getPrefix(element.library);
           Element enclosingElement = element.enclosingElement;
           if (enclosingElement is ClassElement) {
-            prefix += "${enclosingElement.name}.";
+            prefix += '${enclosingElement.name}.';
           }
           if (_isPrivateName(element.name)) {
-            await _severe("Cannot access private name ${element.name}, "
-                "needed for expression $expression");
+            await _severe('Cannot access private name ${element.name}, '
+                'needed for expression $expression');
           }
-          return "$prefix${element.name}";
+          return '$prefix${element.name}';
         } else {
-          await _severe("Cannot access library ${element.library}, "
-              "needed for expression $expression");
-          return "";
+          await _severe('Cannot access library ${element.library}, '
+              'needed for expression $expression');
+          return '';
         }
       }
     } else if (expression is BinaryExpression) {
       String a = await helper(expression.leftOperand);
       String op = expression.operator.lexeme;
       String b = await helper(expression.rightOperand);
-      return "$a $op $b";
+      return '$a $op $b';
     } else if (expression is ConditionalExpression) {
       String condition = await helper(expression.condition);
       String a = await helper(expression.thenExpression);
       String b = await helper(expression.elseExpression);
-      return "$condition ? $a : $b";
+      return '$condition ? $a : $b';
     } else if (expression is ParenthesizedExpression) {
       String nested = await helper(expression.expression);
-      return "($nested)";
+      return '($nested)';
     } else if (expression is PropertyAccess) {
       String target = await helper(expression.target);
       String selector = expression.propertyName.token.lexeme;
-      return "$target.$selector";
+      return '$target.$selector';
     } else if (expression is MethodInvocation) {
-      // We only handle "identical(a, b)".
+      // We only handle 'identical(a, b)'.
       assert(expression.target == null);
-      assert(expression.methodName.token.lexeme == "identical");
+      assert(expression.methodName.token.lexeme == 'identical');
       var arguments = expression.argumentList.arguments;
       assert(arguments.length == 2);
       String a = await helper(arguments[0]);
       String b = await helper(arguments[1]);
-      return "identical($a, $b)";
+      return 'identical($a, $b)';
     } else if (expression is NamedExpression) {
       String value = await _extractConstantCode(
           expression.expression, importCollector, generatedLibraryId, resolver);
-      return "${expression.name} $value";
+      return '${expression.name} $value';
     } else {
       assert(expression is IntegerLiteral ||
           expression is BooleanLiteral ||
@@ -4596,27 +4618,27 @@ Future<String> _extractConstantCode(
 }
 
 /// The names of the libraries that can be accessed with a 'dart:x' import uri.
-Set<String> sdkLibraryNames = Set.from([
-  "async",
-  "collection",
-  "convert",
-  "core",
-  "developer",
-  "html",
-  "indexed_db",
-  "io",
-  "isolate",
-  "js",
-  "math",
-  "mirrors",
-  "profiler",
-  "svg",
-  "typed_data",
-  "ui",
-  "web_audio",
-  "web_gl",
-  "web_sql"
-]);
+const Set<String> sdkLibraryNames = <String>{
+  'async',
+  'collection',
+  'convert',
+  'core',
+  'developer',
+  'html',
+  'indexed_db',
+  'io',
+  'isolate',
+  'js',
+  'math',
+  'mirrors',
+  'profiler',
+  'svg',
+  'typed_data',
+  'ui',
+  'web_audio',
+  'web_gl',
+  'web_sql'
+};
 
 // Helper for _extractMetadataCode.
 CompilationUnit _definingCompilationUnit(
@@ -4683,20 +4705,20 @@ NodeList<Annotation> _getOtherMetadata(
 /// Also adds any neccessary imports to [importCollector].
 Future<String> _extractMetadataCode(Element element, Resolver resolver,
     _ImportCollector importCollector, AssetId dataId) async {
-  if (element.metadata == null) return "const []";
+  if (element.metadata == null) return 'const []';
 
   // Synthetic accessors do not have metadata. Only their associated fields.
   if ((element is PropertyAccessorElement ||
           element is ConstructorElement ||
           element is MixinApplication) &&
       element.isSynthetic) {
-    return "const []";
+    return 'const []';
   }
 
   // TODO(eernst): 'dart:*' is not considered valid. To survive, we return
   // the empty metadata for elements from 'dart:*'. Issue 173.
   if (_isPlatformLibrary(element.library)) {
-    return "const []";
+    return 'const []';
   }
 
   NodeList<Annotation> metadata;
@@ -4707,7 +4729,7 @@ Future<String> _extractMetadataCode(Element element, Resolver resolver,
   } else {
     metadata = _getOtherMetadata(resolvedLibrary, element);
   }
-  if (metadata == null || metadata.isEmpty) return "const []";
+  if (metadata == null || metadata.isEmpty) return 'const []';
 
   List<String> metadataParts = <String>[];
   for (Annotation annotationNode in metadata) {
@@ -4718,7 +4740,7 @@ Future<String> _extractMetadataCode(Element element, Resolver resolver,
       // the analyzer. Ignore them.
       // TODO(sigurdm) clarify: Investigate this, and see if these constants can
       // somehow be included.
-      await _fine("Ignoring unresolved metadata $annotationNode", element);
+      await _fine('Ignoring unresolved metadata $annotationNode', element);
       continue;
     }
 
@@ -4728,7 +4750,7 @@ Future<String> _extractMetadataCode(Element element, Resolver resolver,
       // Skip them.
       // TODO(sigurdm) clarify: Investigate this, and see if these constants can
       // somehow be included.
-      await _fine("Ignoring unrepresentable metadata $annotationNode", element);
+      await _fine('Ignoring unrepresentable metadata $annotationNode', element);
       continue;
     }
     LibraryElement annotationLibrary = annotationNode.element.library;
@@ -4743,27 +4765,27 @@ Future<String> _extractMetadataCode(Element element, Resolver resolver,
         argumentList.add(await _extractConstantCode(
             argument, importCollector, dataId, resolver));
       }
-      String arguments = argumentList.join(", ");
+      String arguments = argumentList.join(', ');
       if (_isPrivateName(name)) {
-        await _severe("Cannot access private name $name", element);
+        await _severe('Cannot access private name $name', element);
       }
-      metadataParts.add("const $prefix$name($arguments)");
+      metadataParts.add('const $prefix$name($arguments)');
     } else {
       // A field reference.
       if (_isPrivateName(annotationNode.name.name)) {
         await _severe(
-            "Cannot access private name ${annotationNode.name}", element);
+            'Cannot access private name ${annotationNode.name}', element);
       }
       String name =
           await _extractNameWithoutPrefix(annotationNode.name, element);
       if (_isPrivateName(name)) {
-        await _severe("Cannot access private name $name", element);
+        await _severe('Cannot access private name $name', element);
       }
-      metadataParts.add("$prefix$name");
+      metadataParts.add('$prefix$name');
     }
   }
 
-  return _formatAsConstList("Object", metadataParts);
+  return _formatAsConstList('Object', metadataParts);
 }
 
 /// Extract the plain name from [identifier] by stripping off the
@@ -4787,7 +4809,7 @@ Future<String> _extractNameWithoutPrefix(
       name = identifier.name;
     }
   } else {
-    await _severe("This kind of identifier is not yet supported: $identifier",
+    await _severe('This kind of identifier is not yet supported: $identifier',
         errorTarget);
     name = identifier.name;
   }
@@ -4803,7 +4825,7 @@ Iterable<TopLevelVariableElement> _extractDeclaredVariables(Resolver resolver,
     for (TopLevelVariableElement variable in unit.topLevelVariables) {
       if (variable.isPrivate || variable.isSynthetic) continue;
       // TODO(eernst) clarify: Do we want to subsume variables under invoke?
-      if (capabilities.supportsTopLevelInvoke(
+      if (capabilities.supportsTopLevelInvoke(variable.library.typeSystem,
           variable.name, variable.metadata, null)) {
         yield variable;
       }
@@ -4819,7 +4841,7 @@ Iterable<FunctionElement> _extractDeclaredFunctions(Resolver resolver,
   for (CompilationUnitElement unit in libraryElement.units) {
     for (FunctionElement function in unit.functions) {
       if (function.isPrivate) continue;
-      if (capabilities.supportsTopLevelInvoke(
+      if (capabilities.supportsTopLevelInvoke(function.library.typeSystem,
           function.name, function.metadata, null)) {
         yield function;
       }
@@ -4845,7 +4867,8 @@ Iterable<ParameterElement> _extractDeclaredFunctionParameters(
   return result;
 }
 
-typedef bool CapabilityChecker(
+typedef CapabilityChecker = bool Function(
+    TypeSystem,
     String methodName,
     Iterable<ElementAnnotation> metadata,
     Iterable<ElementAnnotation> getterMetadata);
@@ -4860,7 +4883,8 @@ Iterable<FieldElement> _extractDeclaredFields(
         ? capabilities.supportsStaticInvoke
         : capabilities.supportsInstanceInvoke;
     return !field.isSynthetic &&
-        capabilityChecker(field.name, field.metadata, null);
+        capabilityChecker(
+            classElement.library.typeSystem, field.name, field.metadata, null);
   });
 }
 
@@ -4873,7 +4897,8 @@ Iterable<MethodElement> _extractDeclaredMethods(
     CapabilityChecker capabilityChecker = method.isStatic
         ? capabilities.supportsStaticInvoke
         : capabilities.supportsInstanceInvoke;
-    return capabilityChecker(method.name, method.metadata, null);
+    return capabilityChecker(
+        method.library.typeSystem, method.name, method.metadata, null);
   });
 }
 
@@ -4920,7 +4945,7 @@ Iterable<PropertyAccessorElement> _extractLibraryAccessors(Resolver resolver,
           getterMetadata = correspondingGetter?.metadata;
         }
       }
-      if (capabilities.supportsTopLevelInvoke(
+      if (capabilities.supportsTopLevelInvoke(accessor.library.typeSystem,
           accessor.name, metadata, getterMetadata)) {
         yield accessor;
       }
@@ -4957,7 +4982,8 @@ Iterable<PropertyAccessorElement> _extractAccessors(
           accessor.correspondingGetter;
       getterMetadata = correspondingGetter?.metadata;
     }
-    return capabilityChecker(accessor.name, metadata, getterMetadata);
+    return capabilityChecker(
+        accessor.library.typeSystem, accessor.name, metadata, getterMetadata);
   });
 }
 
@@ -4970,7 +4996,7 @@ Iterable<ConstructorElement> _extractDeclaredConstructors(
     _Capabilities capabilities) {
   return classElement.constructors.where((ConstructorElement constructor) {
     if (constructor.isPrivate) return false;
-    return capabilities.supportsNewInstance(
+    return capabilities.supportsNewInstance(constructor.library.typeSystem,
         constructor.name, constructor.metadata, libraryElement, resolver);
   });
 }
@@ -5065,7 +5091,7 @@ Future<bool> _isImportable(
 Future<bool> _isImportableLibrary(LibraryElement library,
     AssetId generatedLibraryId, Resolver resolver) async {
   Uri importUri = await _getImportUri(library, generatedLibraryId);
-  return importUri.scheme != "dart" || sdkLibraryNames.contains(importUri.path);
+  return importUri.scheme != 'dart' || sdkLibraryNames.contains(importUri.path);
 }
 
 /// Gets a URI which would be appropriate for importing the file represented by
@@ -5078,7 +5104,7 @@ Future<String> _assetIdToUri(
     // Cannot do absolute imports of non lib-based assets.
     if (assetId.package != from.package) {
       await _severe(await _formatDiagnosticMessage(
-          "Attempt to generate non-lib import from different package",
+          'Attempt to generate non-lib import from different package',
           messageTarget));
       return null;
     }
@@ -5148,9 +5174,9 @@ class MixinApplication implements ClassElement {
   String get name {
     if (declaredName != null) return declaredName;
     if (superclass is MixinApplication) {
-      return "${superclass.name}, ${_qualifiedName(mixin)}";
+      return '${superclass.name}, ${_qualifiedName(mixin)}';
     } else {
-      return "${_qualifiedName(superclass)} with ${_qualifiedName(mixin)}";
+      return '${_qualifiedName(superclass)} with ${_qualifiedName(mixin)}';
     }
   }
 
@@ -5196,13 +5222,13 @@ class MixinApplication implements ClassElement {
   Source get librarySource => library.source;
 
   @override
-  get session => mixin.session;
+  AnalysisSession get session => mixin.session;
 
   @override
-  get source => mixin.source;
+  Source get source => mixin.source;
 
   @override
-  get nameOffset => -1;
+  int get nameOffset => -1;
 
   /// Returns true iff this class was declared using the syntax
   /// `class B = A with M;`, i.e., if it is an explicitly named mixin
@@ -5242,18 +5268,18 @@ class MixinApplication implements ClassElement {
   int get hashCode => superclass.hashCode ^ mixin.hashCode ^ library.hashCode;
 
   @override
-  toString() => "MixinApplication($superclass, $mixin)";
+  String toString() => 'MixinApplication($superclass, $mixin)';
 
   // Let the compiler generate forwarders for all remaining methods: Instances
   // of this class are only ever passed around locally in this library, so
   // we will never need to support any members that we don't use locally.
   @override
-  noSuchMethod(Invocation invocation) {
-    log.severe("Missing MixinApplication member: ${invocation.memberName}");
+  dynamic noSuchMethod(Invocation invocation) {
+    log.severe('Missing MixinApplication member: ${invocation.memberName}');
   }
 }
 
-bool _isSetterName(String name) => name.endsWith("=");
+bool _isSetterName(String name) => name.endsWith('=');
 
 String _setterNameToGetterName(String name) {
   assert(_isSetterName(name));
@@ -5261,23 +5287,23 @@ String _setterNameToGetterName(String name) {
 }
 
 String _qualifiedName(Element element) {
-  return element == null ? "null" : "${element.library.name}.${element.name}";
+  return element == null ? 'null' : '${element.library.name}.${element.name}';
 }
 
 String _qualifiedFunctionName(FunctionElement functionElement) {
   return functionElement == null
-      ? "null"
-      : "${functionElement.library.name}.${functionElement.name}";
+      ? 'null'
+      : '${functionElement.library.name}.${functionElement.name}';
 }
 
 String _qualifiedTypeParameterName(TypeParameterElement typeParameterElement) {
-  if (typeParameterElement == null) return "null";
-  return "${_qualifiedName(typeParameterElement.enclosingElement)}."
-      "${typeParameterElement.name}";
+  if (typeParameterElement == null) return 'null';
+  return '${_qualifiedName(typeParameterElement.enclosingElement)}.'
+      '${typeParameterElement.name}';
 }
 
 bool _isPrivateName(String name) {
-  return name.startsWith("_") || name.contains("._");
+  return name.startsWith('_') || name.contains('._');
 }
 
 EvaluationResult _evaluateConstant(
@@ -5307,7 +5333,7 @@ Iterable<DartObject> _getEvaluatedMetadata(
 /// `getResolvedLibraryByElement`, such that subsequent use will throw.
 /// Issue 173.
 bool _isPlatformLibrary(LibraryElement libraryElement) =>
-    libraryElement.source.uri.scheme == "dart";
+    libraryElement.source.uri.scheme == 'dart';
 
 /// Adds a severe error to the log, using the source code location of `target`
 /// to identify the relevant location where the error occurs.
@@ -5334,7 +5360,7 @@ Future<void> _fine(String message, [Element target]) async {
 Future<String> _formatDiagnosticMessage(String message, Element target) async {
   Source source = target?.source;
   if (source == null) return message;
-  String locationString = "";
+  String locationString = '';
   int nameOffset = target?.nameOffset;
   // TODO(eernst): 'dart:*' is not considered valid. To survive, we return
   // a message with no location info when `element` is from 'dart:*'. Issue 173.
@@ -5345,10 +5371,10 @@ Future<String> _formatDiagnosticMessage(String message, Element target) async {
     final unit = targetDeclaration.resolvedUnit.unit;
     final location = unit.lineInfo?.getLocation(nameOffset);
     if (location != null) {
-      locationString = "${location.lineNumber}:${location.columnNumber}";
+      locationString = '${location.lineNumber}:${location.columnNumber}';
     }
   }
-  return "${source.fullName}:$locationString: $message";
+  return '${source.fullName}:$locationString: $message';
 }
 
 // Emits a warning-level log message which will be preserved by `pub run`

--- a/lib/src/builder_implementation.dart
+++ b/lib/src/builder_implementation.dart
@@ -4119,6 +4119,8 @@ import 'dart:core';
 ${imports.join('\n')}
 
 // ignore_for_file: unnecessary_const
+// ignore_for_file: prefer_collection_literals
+// ignore_for_file: prefer_adjacent_string_concatenation
 
 // ignore:unused_import
 import 'package:reflectable/mirrors.dart' as m;

--- a/lib/src/element_capability.dart
+++ b/lib/src/element_capability.dart
@@ -43,7 +43,7 @@ class InstanceInvokeCapability extends NamePatternCapability {
   const InstanceInvokeCapability(String namePattern) : super(namePattern);
 }
 
-const instanceInvokeCapability = InstanceInvokeCapability("");
+const instanceInvokeCapability = InstanceInvokeCapability('');
 
 class InstanceInvokeMetaCapability extends MetadataQuantifiedCapability {
   const InstanceInvokeMetaCapability(ClassElement metadataType)
@@ -55,7 +55,7 @@ class StaticInvokeCapability extends NamePatternCapability
   const StaticInvokeCapability(String namePattern) : super(namePattern);
 }
 
-const staticInvokeCapability = StaticInvokeCapability("");
+const staticInvokeCapability = StaticInvokeCapability('');
 
 class StaticInvokeMetaCapability extends MetadataQuantifiedCapability
     implements TypeCapability {
@@ -77,7 +77,7 @@ class NewInstanceCapability extends NamePatternCapability
   const NewInstanceCapability(String namePattern) : super(namePattern);
 }
 
-const newInstanceCapability = NewInstanceCapability("");
+const newInstanceCapability = NewInstanceCapability('');
 
 class NewInstanceMetaCapability extends MetadataQuantifiedCapability
     implements TypeCapability {
@@ -165,7 +165,7 @@ class InvokingCapability extends NamePatternCapability
   const InvokingCapability(String namePattern) : super(namePattern);
 }
 
-const invokingCapability = InvokingCapability("");
+const invokingCapability = InvokingCapability('');
 
 class InvokingMetaCapability extends MetadataQuantifiedCapability
     implements

--- a/lib/src/fixed_point.dart
+++ b/lib/src/fixed_point.dart
@@ -14,10 +14,10 @@ abstract class FixedPoint<T> {
   /// Finally it also returns the expanded `initialSet`.
   Future<Set<T>> expand(final Set<T> initialSet) async {
     // Invariant: Every element that may have successors is in `workingSet`.
-    Set<T> workingSet = initialSet;
+    var workingSet = initialSet;
     bool isNew(T element) => !initialSet.contains(element);
     while (workingSet.isNotEmpty) {
-      Set<T> newSet = Set<T>();
+      var newSet = <T>{};
       Future<void> addSuccessors(T element) async =>
           (await successors(element)).where(isNew).forEach(newSet.add);
       for (var t in workingSet) {
@@ -32,7 +32,7 @@ abstract class FixedPoint<T> {
   /// Expands the given `initialSet` a single time, adding the immediate
   /// [successors] to it. Then it returns the expanded `initialSet`.
   Future<Set<T>> singleExpand(final Set<T> initialSet) async {
-    Set<T> newSet = Set<T>();
+    var newSet = <T>{};
     Future<void> addSuccessors(T t) async =>
         (await successors(t)).forEach(newSet.add);
     for (var t in initialSet) {

--- a/lib/src/incompleteness.dart
+++ b/lib/src/incompleteness.dart
@@ -16,7 +16,7 @@ class UnreachableError extends Error {
   UnreachableError(this.message);
 
   @override
-  toString() => message;
+  String toString() => message;
 }
 
 /// Used to throw an [UnreachableError]. Can be invoked with
@@ -24,9 +24,9 @@ class UnreachableError extends Error {
 /// expression throws (even though it actually happens here). This way we avoid
 /// warnings about a missing return problem, and the code may be more readable.
 Null unreachableError(String message) {
-  String extendedMessage =
-      "*** Unexpected situation encountered!\nPlease report a bug on "
-      "github.com/dart-lang/reflectable: $message.";
+  var extendedMessage =
+      '*** Unexpected situation encountered!\nPlease report a bug on '
+      'github.com/dart-lang/reflectable: $message.';
   throw UnreachableError(extendedMessage);
 }
 
@@ -36,9 +36,9 @@ Null unreachableError(String message) {
 /// avoid warnings about a missing return problem, and the code may be more
 /// readable.
 Null unimplementedError(String message) {
-  String extendedMessage = "*** Unfortunately, this feature has not yet been "
-      "implemented: $message.\n"
-      "If you wish to ensure that it is prioritized, please report it "
-      "on github.com/dart-lang/reflectable.";
+  var extendedMessage = '*** Unfortunately, this feature has not yet been '
+      'implemented: $message.\n'
+      'If you wish to ensure that it is prioritized, please report it '
+      'on github.com/dart-lang/reflectable.';
   throw UnimplementedError(extendedMessage);
 }

--- a/lib/src/incompleteness.dart
+++ b/lib/src/incompleteness.dart
@@ -14,6 +14,8 @@ library reflectable.src.incompleteness;
 class UnreachableError extends Error {
   final String message;
   UnreachableError(this.message);
+
+  @override
   toString() => message;
 }
 

--- a/lib/src/reflectable_base.dart
+++ b/lib/src/reflectable_base.dart
@@ -34,7 +34,7 @@ class ReflectableBase {
   /// of classes having an instance of this ReflectableBase as metadata.
   List<ReflectCapability> get capabilities {
     if (_capabilitiesGivenAsList) return _capabilities;
-    List<ReflectCapability> result = <ReflectCapability>[];
+    var result = <ReflectCapability>[];
     void add(ReflectCapability cap) {
       if (cap != null) result.add(cap);
     }

--- a/lib/src/reflectable_builder_based.dart
+++ b/lib/src/reflectable_builder_based.dart
@@ -1951,8 +1951,6 @@ abstract class ImplicitAccessorMirrorImpl extends _DataCaching
   final ReflectableImpl _reflector;
 
   final int _variableMirrorIndex;
-  final int _reflectedTypeIndex;
-  final int _dynamicReflectedTypeIndex;
 
   /// Index of this [ImplicitAccessorMirrorImpl] in `_data.memberMirrors`.
   final int _selfIndex;
@@ -1961,11 +1959,7 @@ abstract class ImplicitAccessorMirrorImpl extends _DataCaching
       _data.memberMirrors[_variableMirrorIndex];
 
   ImplicitAccessorMirrorImpl(
-      this._reflector,
-      this._variableMirrorIndex,
-      this._reflectedTypeIndex,
-      this._dynamicReflectedTypeIndex,
-      this._selfIndex);
+      this._reflector, this._variableMirrorIndex, this._selfIndex);
 
   int get kind => constants.kindFromEncoding(_variableMirror._descriptor);
 
@@ -2038,10 +2032,9 @@ abstract class ImplicitAccessorMirrorImpl extends _DataCaching
 }
 
 class ImplicitGetterMirrorImpl extends ImplicitAccessorMirrorImpl {
-  ImplicitGetterMirrorImpl(ReflectableImpl reflector, int variableMirrorIndex,
-      int reflectedTypeIndex, int dynamicReflectedTypeIndex, int selfIndex)
-      : super(reflector, variableMirrorIndex, reflectedTypeIndex,
-            dynamicReflectedTypeIndex, selfIndex);
+  ImplicitGetterMirrorImpl(
+      ReflectableImpl reflector, int variableMirrorIndex, int selfIndex)
+      : super(reflector, variableMirrorIndex, selfIndex);
 
   @override
   bool get isGetter => true;
@@ -2069,10 +2062,9 @@ class ImplicitGetterMirrorImpl extends ImplicitAccessorMirrorImpl {
 }
 
 class ImplicitSetterMirrorImpl extends ImplicitAccessorMirrorImpl {
-  ImplicitSetterMirrorImpl(ReflectableImpl reflector, int variableMirrorIndex,
-      int reflectedTypeIndex, int dynamicReflectedTypeIndex, int selfIndex)
-      : super(reflector, variableMirrorIndex, reflectedTypeIndex,
-            dynamicReflectedTypeIndex, selfIndex);
+  ImplicitSetterMirrorImpl(
+      ReflectableImpl reflector, int variableMirrorIndex, int selfIndex)
+      : super(reflector, variableMirrorIndex, selfIndex);
 
   @override
   bool get isGetter => false;

--- a/lib/src/reflectable_builder_based.dart
+++ b/lib/src/reflectable_builder_based.dart
@@ -199,7 +199,10 @@ abstract class _DataCaching {
 }
 
 class _InstanceMirrorImpl extends _DataCaching implements InstanceMirror {
+  @override
   final ReflectableImpl _reflector;
+
+  @override
   final Object reflectee;
 
   _InstanceMirrorImpl(this.reflectee, this._reflector) {
@@ -223,6 +226,7 @@ class _InstanceMirrorImpl extends _DataCaching implements InstanceMirror {
 
   ClassMirrorBase _type;
 
+  @override
   ClassMirror get type {
     if (!_supportsType) {
       throw NoSuchCapabilityError(
@@ -231,6 +235,7 @@ class _InstanceMirrorImpl extends _DataCaching implements InstanceMirror {
     return _type;
   }
 
+  @override
   Object invoke(String methodName, List<Object> positionalArguments,
       [Map<Symbol, Object> namedArguments]) {
     void fail() {
@@ -263,14 +268,17 @@ class _InstanceMirrorImpl extends _DataCaching implements InstanceMirror {
         methodTearer(reflectee), positionalArguments, namedArguments);
   }
 
+  @override
   bool get hasReflectee => true;
 
+  @override
   bool operator ==(other) {
     return other is _InstanceMirrorImpl &&
         other._reflector == _reflector &&
         other.reflectee == reflectee;
   }
 
+  @override
   int get hashCode => _reflector.hashCode ^ reflectee.hashCode;
 
   @override
@@ -357,6 +365,7 @@ typedef MethodMirror MethodMirrorProvider(String methodName);
 abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
   /// The reflector which represents the mirror system that this
   /// mirror belongs to.
+  @override
   final ReflectableImpl _reflector;
 
   /// An encoding of the attributes and kind of this class mirror.
@@ -379,6 +388,7 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
   /// itself.
   final int _mixinIndex;
 
+  @override
   List<ClassMirror> get superinterfaces {
     if (_superinterfaceIndices.length == 1 &&
         _superinterfaceIndices[0] == NO_CAPABILITY_INDEX) {
@@ -428,8 +438,12 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
   /// superinterfaces of the reflected class.
   final List<int> _superinterfaceIndices;
 
+  @override
   final String simpleName;
+
+  @override
   final String qualifiedName;
+
   final List<Object> _metadata;
   final Map<String, _StaticGetter> _getters;
   final Map<String, _StaticSetter> _setters;
@@ -455,10 +469,12 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
       this._metadata,
       this._parameterListShapes);
 
+  @override
   bool get isAbstract => (_descriptor & constants.abstractAttribute != 0);
 
   Map<String, DeclarationMirror> _declarations;
 
+  @override
   Map<String, DeclarationMirror> get declarations {
     if (_declarations == null) {
       Map<String, DeclarationMirror> result = <String, DeclarationMirror>{};
@@ -484,6 +500,7 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
 
   Map<String, MethodMirror> _instanceMembers;
 
+  @override
   Map<String, MethodMirror> get instanceMembers {
     if (_instanceMembers == null) {
       if (_instanceMemberIndices == null) {
@@ -504,6 +521,7 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
 
   Map<String, MethodMirror> _staticMembers;
 
+  @override
   Map<String, MethodMirror> get staticMembers {
     if (_staticMembers == null) {
       if (_staticMemberIndices == null) {
@@ -522,6 +540,7 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
     return _staticMembers;
   }
 
+  @override
   ClassMirror get mixin {
     if (_mixinIndex == NO_CAPABILITY_INDEX) {
       if (!_supportsTypeRelations(_reflector)) {
@@ -615,6 +634,7 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
         namedArgumentNames, (String name) => staticMembers[name]);
   }
 
+  @override
   Object newInstance(String constructorName, List positionalArguments,
       [Map<Symbol, dynamic> namedArguments]) {
     void fail() {
@@ -767,6 +787,7 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
         classMirror is ClassMirrorBase && classMirror._isSubtypeOf(other));
   }
 
+  @override
   bool isSubclassOf(ClassMirror other) {
     if (_superclassIndex == NO_CAPABILITY_INDEX) {
       // There are two possible reasons for this: (1) If we have no type
@@ -816,6 +837,7 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
     return _data.libraryMirrors[_ownerIndex];
   }
 
+  @override
   ClassMirrorBase get superclass {
     if (_superclassIndex == NO_CAPABILITY_INDEX) {
       if (!_supportsTypeRelations(_reflector)) {
@@ -939,6 +961,7 @@ class NonGenericClassMirrorImpl extends ClassMirrorBase {
   // type/reflector-combination we can rely on the default `hashCode` and `==`
   // operations.
 
+  @override
   String toString() => "NonGenericClassMirrorImpl($qualifiedName)";
 }
 
@@ -1097,6 +1120,7 @@ class GenericClassMirrorImpl extends ClassMirrorBase {
   // type/reflector-combination we can rely on the default `hashCode` and `==`
   // operations.
 
+  @override
   String toString() => "GenericClassMirrorImpl($qualifiedName)";
 }
 
@@ -1212,6 +1236,7 @@ class InstantiatedGenericClassMirrorImpl extends ClassMirrorBase {
   @override
   Type get dynamicReflectedType => _originalDeclaration.dynamicReflectedType;
 
+  @override
   bool operator ==(other) {
     // The same object twice: Were obtained in the same context, must model the
     // same type, are equal.
@@ -1250,8 +1275,10 @@ class InstantiatedGenericClassMirrorImpl extends ClassMirrorBase {
   // Note that this will equip some instances with the same [hashCode] even
   // though they are not equal according to `operator ==`, namely the ones
   // where both have no `_reflectedType`. This does not compromise correctness.
+  @override
   int get hashCode => originalDeclaration.hashCode ^ _reflectedType.hashCode;
 
+  @override
   String toString() => "InstantiatedGenericClassMirrorImpl($qualifiedName)";
 }
 
@@ -1288,14 +1315,17 @@ InstantiatedGenericClassMirrorImpl _createInstantiatedGenericClass(
 class TypeVariableMirrorImpl extends _DataCaching
     implements TypeVariableMirror {
   /// The simple name of this type variable.
+  @override
   final String simpleName;
 
   /// The qualified name of this type variable, i.e., the qualified name of
   /// the declaring class followed by its simple name.
+  @override
   final String qualifiedName;
 
   /// The reflector which represents the mirror system that this
   /// mirror belongs to.
+  @override
   final ReflectableImpl _reflector;
 
   /// The index into [typeMirrors] of the upper bound of this type variable.
@@ -1429,6 +1459,7 @@ class TypeVariableMirrorImpl extends _DataCaching
 }
 
 class LibraryMirrorImpl extends _DataCaching implements LibraryMirror {
+  @override
   final ReflectableImpl _reflector;
 
   /// A list of the indices in [ReflectorData.memberMirrors] of the
@@ -1619,6 +1650,7 @@ class LibraryMirrorImpl extends _DataCaching implements LibraryMirror {
   @override
   String get qualifiedName => simpleName;
 
+  @override
   bool operator ==(other) {
     return other is LibraryMirrorImpl &&
         other.uri == uri &&
@@ -1626,11 +1658,13 @@ class LibraryMirrorImpl extends _DataCaching implements LibraryMirror {
         other._declarationIndices == _declarationIndices;
   }
 
+  @override
   int get hashCode =>
       uri.hashCode ^ _reflector.hashCode ^ _declarationIndices.hashCode;
 
   // TODO(sigurdm) implement: Need to implement this, with the requirement that
   // a [LibraryCapability] must be available.
+  @override
   List<LibraryDependencyMirror> get libraryDependencies =>
       throw unimplementedError("libraryDependencies");
 }
@@ -1671,6 +1705,7 @@ class MethodMirrorImpl extends _DataCaching implements MethodMirror {
   final List<int> _parameterIndices;
 
   /// The [Reflectable] associated with this mirror.
+  @override
   final ReflectableImpl _reflector;
 
   /// The metadata of the mirrored method. The empty list means no metadata,
@@ -1692,6 +1727,7 @@ class MethodMirrorImpl extends _DataCaching implements MethodMirror {
 
   int get kind => constants.kindFromEncoding(_descriptor);
 
+  @override
   DeclarationMirror get owner {
     if (_ownerIndex == NO_CAPABILITY_INDEX) {
       throw NoSuchCapabilityError(
@@ -1909,7 +1945,9 @@ class MethodMirrorImpl extends _DataCaching implements MethodMirror {
 
 abstract class ImplicitAccessorMirrorImpl extends _DataCaching
     implements MethodMirror {
+  @override
   final ReflectableImpl _reflector;
+
   final int _variableMirrorIndex;
   final int _reflectedTypeIndex;
   final int _dynamicReflectedTypeIndex;
@@ -1929,6 +1967,7 @@ abstract class ImplicitAccessorMirrorImpl extends _DataCaching
 
   int get kind => constants.kindFromEncoding(_variableMirror._descriptor);
 
+  @override
   DeclarationMirror get owner => _variableMirror.owner;
 
   @override
@@ -2089,7 +2128,10 @@ abstract class VariableMirrorBase extends _DataCaching
   final String _name;
   final int _descriptor;
   final int _ownerIndex;
+
+  @override
   final ReflectableImpl _reflector;
+
   final int _classMirrorIndex;
   final int _reflectedTypeIndex;
   final int _dynamicReflectedTypeIndex;
@@ -2194,6 +2236,7 @@ abstract class VariableMirrorBase extends _DataCaching
           : reflectedType;
 
   /// Override requested by linter.
+  @override
   bool operator ==(other);
 
   // Note that [operator ==] is redefined slightly differently in the two
@@ -2251,6 +2294,7 @@ class VariableMirrorImpl extends VariableMirrorBase {
       other.owner == owner;
 
   /// Override requested by linter.
+  @override
   int get hashCode;
 }
 
@@ -2326,6 +2370,7 @@ class ParameterMirrorImpl extends VariableMirrorBase
       other.owner == owner;
 
   /// Override requested by linter.
+  @override
   int get hashCode;
 }
 
@@ -2565,6 +2610,7 @@ class FakeType implements Type {
 
   final String description;
 
+  @override
   String toString() => "Type($description)";
 }
 

--- a/lib/src/reflectable_builder_based.dart
+++ b/lib/src/reflectable_builder_based.dart
@@ -14,6 +14,8 @@ import 'encoding_constants.dart' show NO_CAPABILITY_INDEX;
 import 'incompleteness.dart';
 import 'reflectable_base.dart';
 
+// ignore_for_file: omit_local_variable_types
+
 /// Returns the set of reflectors in the current program. Note that it only
 /// returns reflectors matching something---a reflector that does not match
 /// anything is not even given a mapping in `data`. This makes sense because
@@ -34,16 +36,16 @@ Set<Reflectable> get reflectors => data.keys.toSet();
 // replicated wherever possible.
 
 /// Invokes a getter on an object.
-typedef Object _InvokerOfGetter(Object instance);
+typedef _InvokerOfGetter = Object Function(Object instance);
 
 /// Invokes a setter on an object.
-typedef Object _InvokerOfSetter(Object instance, Object value);
+typedef _InvokerOfSetter = Object Function(Object instance, Object value);
 
 /// Invokes a static getter.
-typedef Object _StaticGetter();
+typedef _StaticGetter = Object Function();
 
 /// Invokes a setter on an object.
-typedef Object _StaticSetter(Object value);
+typedef _StaticSetter = Object Function(Object value);
 
 /// The data backing a reflector.
 class ReflectorData {
@@ -165,9 +167,9 @@ class ReflectorData {
   }
 }
 
-const String pleaseInitializeMessage = "Reflectable has not been initialized.\n"
-    "Please make sure that the first action taken by your program\n"
-    "in `main` is to call `initializeReflectable()`.";
+const String pleaseInitializeMessage = 'Reflectable has not been initialized.\n'
+    'Please make sure that the first action taken by your program\n'
+    'in `main` is to call `initializeReflectable()`.';
 
 /// This mapping contains the mirror-data for each reflector.
 /// It will be initialized in the generated code.
@@ -217,7 +219,7 @@ class _InstanceMirrorImpl extends _DataCaching implements InstanceMirror {
       // type of the reflectee is known.
       if (!_data.types.contains(reflectee.runtimeType)) {
         throw NoSuchCapabilityError(
-            "Reflecting on un-marked type '${reflectee.runtimeType}'");
+            'Reflecting on un-marked type "${reflectee.runtimeType}"');
       }
     }
   }
@@ -230,7 +232,7 @@ class _InstanceMirrorImpl extends _DataCaching implements InstanceMirror {
   ClassMirror get type {
     if (!_supportsType) {
       throw NoSuchCapabilityError(
-          "Attempt to get `type` without `TypeCapability`.");
+          'Attempt to get `type` without `TypeCapability`.');
     }
     return _type;
   }
@@ -258,7 +260,7 @@ class _InstanceMirrorImpl extends _DataCaching implements InstanceMirror {
       // never generate code that brings us to this location: Every kind of
       // invocation capability should force at least some level of class mirror
       // support.
-      throw unreachableError("Attempt to `invoke` without class mirrors");
+      throw unreachableError('Attempt to `invoke` without class mirrors');
     }
     if (!_type._checkInstanceParameterListShape(
         methodName, positionalArguments.length, namedArguments?.keys)) {
@@ -282,8 +284,8 @@ class _InstanceMirrorImpl extends _DataCaching implements InstanceMirror {
   int get hashCode => _reflector.hashCode ^ reflectee.hashCode;
 
   @override
-  delegate(Invocation invocation) {
-    fail() {
+  dynamic delegate(Invocation invocation) {
+    void fail() {
       StringInvocationKind kind = invocation.isGetter
           ? StringInvocationKind.getter
           : (invocation.isSetter
@@ -295,7 +297,7 @@ class _InstanceMirrorImpl extends _DataCaching implements InstanceMirror {
       // known).
       throw reflectableNoSuchInvokableError(
           reflectee,
-          "${invocation.memberName}",
+          '${invocation.memberName}',
           invocation.positionalArguments,
           invocation.namedArguments,
           kind);
@@ -303,7 +305,7 @@ class _InstanceMirrorImpl extends _DataCaching implements InstanceMirror {
 
     if (memberSymbolMap == null) {
       throw NoSuchCapabilityError(
-          "Attempt to `delegate` without `delegateCapability");
+          'Attempt to `delegate` without `delegateCapability`');
     }
     String memberName = memberSymbolMap[invocation.memberName];
     if (memberName == null) {
@@ -318,15 +320,15 @@ class _InstanceMirrorImpl extends _DataCaching implements InstanceMirror {
           invocation.namedArguments.isNotEmpty) {
         fail();
       }
-      return this.invokeGetter(memberName);
+      return invokeGetter(memberName);
     } else if (invocation.isSetter) {
       if (invocation.positionalArguments.length != 1 ||
           invocation.namedArguments.isNotEmpty) {
         fail();
       }
-      return this.invokeSetter(memberName, invocation.positionalArguments[0]);
+      return invokeSetter(memberName, invocation.positionalArguments[0]);
     } else {
-      return this.invoke(memberName, invocation.positionalArguments,
+      return invoke(memberName, invocation.positionalArguments,
           invocation.namedArguments);
     }
   }
@@ -360,7 +362,7 @@ class _InstanceMirrorImpl extends _DataCaching implements InstanceMirror {
   }
 }
 
-typedef MethodMirror MethodMirrorProvider(String methodName);
+typedef MethodMirrorProvider = MethodMirror Function(String methodName);
 
 abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
   /// The reflector which represents the mirror system that this
@@ -393,8 +395,8 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
     if (_superinterfaceIndices.length == 1 &&
         _superinterfaceIndices[0] == NO_CAPABILITY_INDEX) {
       throw NoSuchCapabilityError(
-          "Requesting `superinterfaces` of `$qualifiedName` "
-          "without `typeRelationsCapability`");
+          'Requesting `superinterfaces` of `$qualifiedName` '
+          'without `typeRelationsCapability`');
     }
     return _superinterfaceIndices.map<ClassMirror>((int i) {
       if (i == NO_CAPABILITY_INDEX) {
@@ -403,8 +405,8 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
         // we do have the `typeRelationsCapability`, but we may still
         // encounter a single unsupported superinterface.
         throw NoSuchCapabilityError(
-            "Requesting a superinterface of '$qualifiedName' "
-            "without capability");
+            'Requesting a superinterface of `$qualifiedName` '
+            'without capability');
       }
       return _data.typeMirrors[i];
     }).toList();
@@ -487,7 +489,7 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
         // that.
         if (declarationIndex == NO_CAPABILITY_INDEX) {
           throw NoSuchCapabilityError(
-              "Requesting declarations of '$qualifiedName' without capability");
+              'Requesting declarations of "$qualifiedName" without capability');
         }
         DeclarationMirror declarationMirror =
             _data.memberMirrors[declarationIndex];
@@ -505,7 +507,7 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
     if (_instanceMembers == null) {
       if (_instanceMemberIndices == null) {
         throw NoSuchCapabilityError(
-            "Requesting instanceMembers without `declarationsCapability`.");
+            'Requesting instanceMembers without `declarationsCapability`.');
       }
       Map<String, MethodMirror> result = <String, MethodMirror>{};
       for (int instanceMemberIndex in _instanceMemberIndices) {
@@ -526,7 +528,7 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
     if (_staticMembers == null) {
       if (_staticMemberIndices == null) {
         throw NoSuchCapabilityError(
-            "Requesting instanceMembers without `declarationsCapability`.");
+            'Requesting instanceMembers without `declarationsCapability`.');
       }
       Map<String, MethodMirror> result = <String, MethodMirror>{};
       for (int staticMemberIndex in _staticMemberIndices) {
@@ -545,11 +547,11 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
     if (_mixinIndex == NO_CAPABILITY_INDEX) {
       if (!_supportsTypeRelations(_reflector)) {
         throw NoSuchCapabilityError(
-            "Attempt to get `mixin` for `$qualifiedName` "
-            "without `typeRelationsCapability`");
+            'Attempt to get `mixin` for `$qualifiedName` '
+            'without `typeRelationsCapability`');
       }
       throw NoSuchCapabilityError(
-          "Attempt to get mixin from '$simpleName' without capability");
+          'Attempt to get mixin from "$simpleName" without capability');
     }
     return _data.typeMirrors[_mixinIndex];
   }
@@ -643,7 +645,7 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
           type, constructorName, positionalArguments, namedArguments);
     }
 
-    Function constructor = _constructors["$constructorName"];
+    Function constructor = _constructors['$constructorName'];
     if (constructor == null) fail();
     try {
       Function.apply(constructor(false), positionalArguments, namedArguments);
@@ -657,7 +659,7 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
   @override
   Object invoke(String memberName, List positionalArguments,
       [Map<Symbol, dynamic> namedArguments]) {
-    fail() {
+    void fail() {
       throw reflectableNoSuchMethodError(
           reflectedType, memberName, positionalArguments, namedArguments);
     }
@@ -703,7 +705,7 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
   bool get isTopLevel => true;
 
   @override
-  SourceLocation get location => throw UnsupportedError("location");
+  SourceLocation get location => throw UnsupportedError('location');
 
   @override
   List<Object> get metadata {
@@ -711,7 +713,7 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
       String description =
           hasReflectedType ? reflectedType.toString() : qualifiedName;
       throw NoSuchCapabilityError(
-          "Requesting metadata of '$description' without capability");
+          'Requesting metadata of "$description" without capability');
     }
     return _metadata;
   }
@@ -737,12 +739,12 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
       // for access to superinterfaces here.
       if (!_supportsTypeRelations(_reflector)) {
         throw NoSuchCapabilityError(
-            "Attempt to evaluate `isAssignableTo` for `$qualifiedName` "
-            "without `typeRelationsCapability`");
+            'Attempt to evaluate `isAssignableTo` for `$qualifiedName` '
+            'without `typeRelationsCapability`');
       }
       throw NoSuchCapabilityError(
-          "Attempt to evaluate `isAssignableTo` for `$qualifiedName` "
-          "without capability.");
+          'Attempt to evaluate `isAssignableTo` for `$qualifiedName` '
+          'without capability.');
     }
     return _isSubtypeOf(other) ||
         (other is ClassMirrorBase && other._isSubtypeOf(this));
@@ -760,12 +762,12 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
       // for access to superinterfaces here.
       if (!_supportsTypeRelations(_reflector)) {
         throw NoSuchCapabilityError(
-            "Attempt to evaluate `isSubtypeOf` for `$qualifiedName` "
-            "without `typeRelationsCapability`");
+            'Attempt to evaluate `isSubtypeOf` for `$qualifiedName` '
+            'without `typeRelationsCapability`');
       }
       throw NoSuchCapabilityError(
-          "Attempt to evaluate `isSubtypeOf` for `$qualifiedName` "
-          "without capability.");
+          'Attempt to evaluate `isSubtypeOf` for `$qualifiedName` '
+          'without capability.');
     }
     return _isSubtypeOf(other);
   }
@@ -799,12 +801,12 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
       // for access to superinterfaces here.
       if (!_supportsTypeRelations(_reflector)) {
         throw NoSuchCapabilityError(
-            "Attempt to evaluate `isSubclassOf` for `$qualifiedName` "
-            "without `typeRelationsCapability`");
+            'Attempt to evaluate `isSubclassOf` for `$qualifiedName` '
+            'without `typeRelationsCapability`');
       }
       throw NoSuchCapabilityError(
-          "Attempt to evaluate `isSubclassOf` for $qualifiedName "
-          "without capability.");
+          'Attempt to evaluate `isSubclassOf` for $qualifiedName '
+          'without capability.');
     }
     return _isSubclassOf(other);
   }
@@ -827,12 +829,12 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
     if (_ownerIndex == NO_CAPABILITY_INDEX) {
       if (!_supportsTypeRelations(_reflector)) {
         throw NoSuchCapabilityError(
-            "Attempt to get `owner` of `$qualifiedName` "
-            "without `typeRelationsCapability`");
+            'Attempt to get `owner` of `$qualifiedName` '
+            'without `typeRelationsCapability`');
       }
       throw NoSuchCapabilityError(
-          "Trying to get owner of class '$qualifiedName' "
-          "without 'libraryCapability'");
+          'Trying to get owner of class `$qualifiedName` '
+          'without `libraryCapability`');
     }
     return _data.libraryMirrors[_ownerIndex];
   }
@@ -842,11 +844,11 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
     if (_superclassIndex == NO_CAPABILITY_INDEX) {
       if (!_supportsTypeRelations(_reflector)) {
         throw NoSuchCapabilityError(
-            "Attempt to get `superclass` of `$qualifiedName` "
-            "without `typeRelationsCapability`");
+            'Attempt to get `superclass` of `$qualifiedName` '
+            'without `typeRelationsCapability`');
       }
-      throw NoSuchCapabilityError("Requesting mirror on un-marked class, "
-          "`superclass` of `$qualifiedName`");
+      throw NoSuchCapabilityError('Requesting mirror on un-marked class, '
+          '`superclass` of `$qualifiedName`');
     }
     if (_superclassIndex == null) return null; // Superclass of [Object].
     return _data.typeMirrors[_superclassIndex];
@@ -905,8 +907,8 @@ class NonGenericClassMirrorImpl extends ClassMirrorBase {
   List<TypeMirror> get typeArguments {
     if (!_supportsTypeRelations(_reflector)) {
       throw NoSuchCapabilityError(
-          "Attempt to get `typeArguments` for `$qualifiedName` "
-          "without `typeRelationsCapability`");
+          'Attempt to get `typeArguments` for `$qualifiedName` '
+          'without `typeRelationsCapability`');
     }
     return const <TypeMirror>[];
   }
@@ -916,8 +918,8 @@ class NonGenericClassMirrorImpl extends ClassMirrorBase {
     if (!_supportsTypeRelations(_reflector) ||
         !_supportsReflectedType(_reflector)) {
       throw NoSuchCapabilityError(
-          "Attempt to get `typeArguments` for `$qualifiedName` "
-          "without `typeRelationsCapability` or `reflectedTypeCapability`");
+          'Attempt to get `typeArguments` for `$qualifiedName` '
+          'without `typeRelationsCapability` or `reflectedTypeCapability`');
     }
     return const <Type>[];
   }
@@ -926,8 +928,8 @@ class NonGenericClassMirrorImpl extends ClassMirrorBase {
   List<TypeVariableMirror> get typeVariables {
     if (!_supportsTypeRelations(_reflector)) {
       throw NoSuchCapabilityError(
-          "Attempt to evaluate `typeVariables` for `$qualifiedName` "
-          "without `typeRelationsCapability`");
+          'Attempt to evaluate `typeVariables` for `$qualifiedName` '
+          'without `typeRelationsCapability`');
     }
     return const <TypeVariableMirror>[];
   }
@@ -939,8 +941,8 @@ class NonGenericClassMirrorImpl extends ClassMirrorBase {
   TypeMirror get originalDeclaration {
     if (!_supportsTypeRelations(_reflector)) {
       throw NoSuchCapabilityError(
-          "Attempt to get `originalDeclaration` for `$qualifiedName` "
-          "without `typeRelationsCapability`");
+          'Attempt to get `originalDeclaration` for `$qualifiedName` '
+          'without `typeRelationsCapability`');
     }
     return this;
   }
@@ -962,10 +964,10 @@ class NonGenericClassMirrorImpl extends ClassMirrorBase {
   // operations.
 
   @override
-  String toString() => "NonGenericClassMirrorImpl($qualifiedName)";
+  String toString() => 'NonGenericClassMirrorImpl($qualifiedName)';
 }
 
-typedef bool InstanceChecker(Object instance);
+typedef InstanceChecker = bool Function(Object);
 
 class GenericClassMirrorImpl extends ClassMirrorBase {
   /// Used to enable instance checks. Let O be an instance and let C denote the
@@ -1028,8 +1030,8 @@ class GenericClassMirrorImpl extends ClassMirrorBase {
   List<TypeMirror> get typeArguments {
     if (!_supportsTypeRelations(_reflector)) {
       throw NoSuchCapabilityError(
-          "Attempt to get `typeArguments` for `$qualifiedName` "
-          "without `typeRelationsCapability`");
+          'Attempt to get `typeArguments` for `$qualifiedName` '
+          'without `typeRelationsCapability`');
     }
     // This mirror represents the original declaration, so no actual type
     // arguments have been passed. By convention we represent this situation
@@ -1042,8 +1044,8 @@ class GenericClassMirrorImpl extends ClassMirrorBase {
     if (!_supportsTypeRelations(_reflector) ||
         !_supportsReflectedType(_reflector)) {
       throw NoSuchCapabilityError(
-          "Attempt to get `reflectedTypeArguments` for `$qualifiedName` "
-          "without `typeRelationsCapability` or `reflectedTypeCapability`");
+          'Attempt to get `reflectedTypeArguments` for `$qualifiedName` '
+          'without `typeRelationsCapability` or `reflectedTypeCapability`');
     }
     // This mirror represents the original declaration, so no actual type
     // arguments have been passed. By convention we represent this situation
@@ -1060,11 +1062,11 @@ class GenericClassMirrorImpl extends ClassMirrorBase {
     if (_typeVariableIndices == null) {
       if (!_supportsTypeRelations(_reflector)) {
         throw NoSuchCapabilityError(
-            "Attempt to evaluate `typeVariables` for `$qualifiedName` "
-            "without `typeRelationsCapability`");
+            'Attempt to evaluate `typeVariables` for `$qualifiedName` '
+            'without `typeRelationsCapability`');
       }
       throw NoSuchCapabilityError(
-          "Requesting type variables of `$qualifiedName` without capability");
+          'Requesting type variables of `$qualifiedName` without capability');
     }
     List<TypeVariableMirror> result = <TypeVariableMirror>[];
     for (int typeVariableIndex in _typeVariableIndices) {
@@ -1083,8 +1085,8 @@ class GenericClassMirrorImpl extends ClassMirrorBase {
   TypeMirror get originalDeclaration {
     if (!_supportsTypeRelations(_reflector)) {
       throw NoSuchCapabilityError(
-          "Attempt to get `originalDeclaration` for `$qualifiedName` "
-          "without `typeRelationsCapability`");
+          'Attempt to get `originalDeclaration` for `$qualifiedName` '
+          'without `typeRelationsCapability`');
     }
     return this;
   }
@@ -1094,8 +1096,8 @@ class GenericClassMirrorImpl extends ClassMirrorBase {
 
   @override
   Type get reflectedType {
-    throw UnsupportedError("Attempt to obtain `reflectedType` "
-        "from generic class '$qualifiedName'.");
+    throw UnsupportedError('Attempt to obtain `reflectedType` '
+        'from generic class `$qualifiedName`.');
   }
 
   @override
@@ -1106,12 +1108,12 @@ class GenericClassMirrorImpl extends ClassMirrorBase {
     if (_dynamicReflectedTypeIndex == NO_CAPABILITY_INDEX) {
       if (!_supportsReflectedType(_reflector)) {
         throw NoSuchCapabilityError(
-            "Attempt to evaluate `dynamicReflectedType` for `$qualifiedName` "
-            "without `reflectedTypeCapability`");
+            'Attempt to evaluate `dynamicReflectedType` for `$qualifiedName` '
+            'without `reflectedTypeCapability`');
       }
       throw NoSuchCapabilityError(
-          "Attempt to get `dynamicReflectedType` for `$qualifiedName` "
-          "without capability");
+          'Attempt to get `dynamicReflectedType` for `$qualifiedName` '
+          'without capability');
     }
     return _data.types[_dynamicReflectedTypeIndex];
   }
@@ -1121,7 +1123,7 @@ class GenericClassMirrorImpl extends ClassMirrorBase {
   // operations.
 
   @override
-  String toString() => "GenericClassMirrorImpl($qualifiedName)";
+  String toString() => 'GenericClassMirrorImpl($qualifiedName)';
 }
 
 class InstantiatedGenericClassMirrorImpl extends ClassMirrorBase {
@@ -1176,8 +1178,8 @@ class InstantiatedGenericClassMirrorImpl extends ClassMirrorBase {
   List<TypeMirror> get typeArguments {
     if (!_supportsTypeRelations(_reflector)) {
       throw NoSuchCapabilityError(
-          "Attempt to get `typeArguments` for `$qualifiedName` "
-          "without `typeRelationsCapability`");
+          'Attempt to get `typeArguments` for `$qualifiedName` '
+          'without `typeRelationsCapability`');
     }
     return reflectedTypeArguments
         .map((Type type) => _reflector.reflectType(type))
@@ -1189,11 +1191,11 @@ class InstantiatedGenericClassMirrorImpl extends ClassMirrorBase {
     if (!_supportsTypeRelations(_reflector) ||
         !_supportsReflectedType(_reflector)) {
       throw NoSuchCapabilityError(
-          "Attempt to get `reflectedTypeArguments` for `$qualifiedName` "
-          "without `typeRelationsCapability` or `reflectedTypeCapability`");
+          'Attempt to get `reflectedTypeArguments` for `$qualifiedName` '
+          'without `typeRelationsCapability` or `reflectedTypeCapability`');
     }
     if (_reflectedTypeArgumentIndices == null) {
-      throw unimplementedError("reflectedTypeArguments");
+      throw unimplementedError('reflectedTypeArguments');
     }
     return _reflectedTypeArgumentIndices
         .map((int index) => _data.types[index])
@@ -1211,8 +1213,8 @@ class InstantiatedGenericClassMirrorImpl extends ClassMirrorBase {
   TypeMirror get originalDeclaration {
     if (!_supportsTypeRelations(_reflector)) {
       throw NoSuchCapabilityError(
-          "Attempt to get `originalDeclaration` for `$qualifiedName` "
-          "without `typeRelationsCapability`");
+          'Attempt to get `originalDeclaration` for `$qualifiedName` '
+          'without `typeRelationsCapability`');
     }
     return _originalDeclaration;
   }
@@ -1225,8 +1227,8 @@ class InstantiatedGenericClassMirrorImpl extends ClassMirrorBase {
     if (_reflectedType != null) {
       return _reflectedType;
     }
-    throw UnsupportedError("Cannot provide `reflectedType` of "
-        "instance of generic type '$simpleName'.");
+    throw UnsupportedError('Cannot provide `reflectedType` of '
+        'instance of generic type `$simpleName`.');
   }
 
   @override
@@ -1279,7 +1281,7 @@ class InstantiatedGenericClassMirrorImpl extends ClassMirrorBase {
   int get hashCode => originalDeclaration.hashCode ^ _reflectedType.hashCode;
 
   @override
-  String toString() => "InstantiatedGenericClassMirrorImpl($qualifiedName)";
+  String toString() => 'InstantiatedGenericClassMirrorImpl($qualifiedName)';
 }
 
 InstantiatedGenericClassMirrorImpl _createInstantiatedGenericClass(
@@ -1350,8 +1352,8 @@ class TypeVariableMirrorImpl extends _DataCaching
   TypeMirror get upperBound {
     if (_upperBoundIndex == null) return DynamicMirrorImpl();
     if (_upperBoundIndex == NO_CAPABILITY_INDEX) {
-      throw NoSuchCapabilityError("Attempt to get `upperBound` from type "
-          "variable mirror without capability.");
+      throw NoSuchCapabilityError('Attempt to get `upperBound` from type '
+          'variable mirror without capability.');
     }
     return _data.typeMirrors[_upperBoundIndex];
   }
@@ -1360,8 +1362,8 @@ class TypeVariableMirrorImpl extends _DataCaching
   bool isAssignableTo(TypeMirror other) {
     if (!_supportsTypeRelations(_reflector)) {
       throw NoSuchCapabilityError(
-          "Attempt to get `isAssignableTo` for `$qualifiedName` "
-          "without `typeRelationsCapability`");
+          'Attempt to get `isAssignableTo` for `$qualifiedName` '
+          'without `typeRelationsCapability`');
     }
     return upperBound.isSubtypeOf(other) || other.isSubtypeOf(this);
   }
@@ -1370,8 +1372,8 @@ class TypeVariableMirrorImpl extends _DataCaching
   bool isSubtypeOf(TypeMirror other) {
     if (!_supportsTypeRelations(_reflector)) {
       throw NoSuchCapabilityError(
-          "Attempt to get `isSubtypeOf` for `$qualifiedName` "
-          "without `typeRelationsCapability`");
+          'Attempt to get `isSubtypeOf` for `$qualifiedName` '
+          'without `typeRelationsCapability`');
     }
     return upperBound.isSubtypeOf(other);
   }
@@ -1380,8 +1382,8 @@ class TypeVariableMirrorImpl extends _DataCaching
   TypeMirror get originalDeclaration {
     if (!_supportsTypeRelations(_reflector)) {
       throw NoSuchCapabilityError(
-          "Attempt to get `originalDeclaration` for `$qualifiedName` "
-          "without `typeRelationsCapability`");
+          'Attempt to get `originalDeclaration` for `$qualifiedName` '
+          'without `typeRelationsCapability`');
     }
     return this;
   }
@@ -1393,8 +1395,8 @@ class TypeVariableMirrorImpl extends _DataCaching
   List<TypeMirror> get typeArguments {
     if (!_supportsTypeRelations(_reflector)) {
       throw NoSuchCapabilityError(
-          "Attempt to get `typeArguments` for `$qualifiedName` "
-          "without `typeRelationsCapability`");
+          'Attempt to get `typeArguments` for `$qualifiedName` '
+          'without `typeRelationsCapability`');
     }
     return const <TypeMirror>[];
   }
@@ -1404,8 +1406,8 @@ class TypeVariableMirrorImpl extends _DataCaching
     if (!_supportsTypeRelations(_reflector) ||
         !_supportsReflectedType(_reflector)) {
       throw NoSuchCapabilityError(
-          "Attempt to get `reflectedTypeArguments` for `$qualifiedName` "
-          "without `typeRelationsCapability` or `reflectedTypeCapability`");
+          'Attempt to get `reflectedTypeArguments` for `$qualifiedName` '
+          'without `typeRelationsCapability` or `reflectedTypeCapability`');
     }
     return const <Type>[];
   }
@@ -1414,16 +1416,16 @@ class TypeVariableMirrorImpl extends _DataCaching
   List<TypeVariableMirror> get typeVariables {
     if (!_supportsTypeRelations(_reflector)) {
       throw NoSuchCapabilityError(
-          "Attempt to evaluate `typeVariables` for `$qualifiedName` "
-          "without `typeRelationsCapability`");
+          'Attempt to evaluate `typeVariables` for `$qualifiedName` '
+          'without `typeRelationsCapability`');
     }
     return <TypeVariableMirror>[];
   }
 
   @override
   Type get reflectedType {
-    throw UnsupportedError("Attempt to get `reflectedType` from type "
-        "variable $simpleName");
+    throw UnsupportedError('Attempt to get `reflectedType` from type '
+        'variable $simpleName');
   }
 
   @override
@@ -1432,14 +1434,14 @@ class TypeVariableMirrorImpl extends _DataCaching
   @override
   List<Object> get metadata {
     if (_metadata == null) {
-      throw NoSuchCapabilityError("Attempt to get `metadata` from type "
-          "variable $simpleName without capability");
+      throw NoSuchCapabilityError('Attempt to get `metadata` from type '
+          'variable $simpleName without capability');
     }
     return <Object>[];
   }
 
   @override
-  SourceLocation get location => throw UnsupportedError("location");
+  SourceLocation get location => throw UnsupportedError('location');
 
   @override
   bool get isTopLevel => false;
@@ -1451,8 +1453,8 @@ class TypeVariableMirrorImpl extends _DataCaching
   DeclarationMirror get owner {
     if (_ownerIndex == NO_CAPABILITY_INDEX) {
       throw NoSuchCapabilityError(
-          "Trying to get owner of type parameter '$qualifiedName' "
-          "without capability");
+          'Trying to get owner of type parameter `$qualifiedName` '
+          'without capability');
     }
     return _data.typeMirrors[_ownerIndex];
   }
@@ -1508,7 +1510,7 @@ class LibraryMirrorImpl extends _DataCaching implements LibraryMirror {
         // that.
         if (declarationIndex == NO_CAPABILITY_INDEX) {
           throw NoSuchCapabilityError(
-              "Requesting declarations of '$qualifiedName' without capability");
+              'Requesting declarations of `$qualifiedName` without capability');
         }
         DeclarationMirror declarationMirror =
             _data.memberMirrors[declarationIndex];
@@ -1589,7 +1591,7 @@ class LibraryMirrorImpl extends _DataCaching implements LibraryMirror {
   @override
   Object invoke(String memberName, List positionalArguments,
       [Map<Symbol, dynamic> namedArguments]) {
-    fail() {
+    void fail() {
       throw reflectableNoSuchMethodError(
           null, memberName, positionalArguments, namedArguments);
     }
@@ -1631,7 +1633,7 @@ class LibraryMirrorImpl extends _DataCaching implements LibraryMirror {
   bool get isTopLevel => false;
 
   @override
-  SourceLocation get location => throw UnsupportedError("location");
+  SourceLocation get location => throw UnsupportedError('location');
 
   final List<Object> _metadata;
 
@@ -1639,7 +1641,7 @@ class LibraryMirrorImpl extends _DataCaching implements LibraryMirror {
   List<Object> get metadata {
     if (_metadata == null) {
       throw NoSuchCapabilityError(
-          "Requesting metadata of library '$simpleName' without capability");
+          'Requesting metadata of library `$simpleName` without capability');
     }
     return _metadata;
   }
@@ -1666,7 +1668,7 @@ class LibraryMirrorImpl extends _DataCaching implements LibraryMirror {
   // a [LibraryCapability] must be available.
   @override
   List<LibraryDependencyMirror> get libraryDependencies =>
-      throw unimplementedError("libraryDependencies");
+      throw unimplementedError('libraryDependencies');
 }
 
 class MethodMirrorImpl extends _DataCaching implements MethodMirror {
@@ -1731,8 +1733,8 @@ class MethodMirrorImpl extends _DataCaching implements MethodMirror {
   DeclarationMirror get owner {
     if (_ownerIndex == NO_CAPABILITY_INDEX) {
       throw NoSuchCapabilityError(
-          "Trying to get owner of method '$qualifiedName' "
-          "without 'LibraryCapability'");
+          'Trying to get owner of method `$qualifiedName` '
+          'without `LibraryCapability`');
     }
     return isTopLevel
         ? _data.libraryMirrors[_ownerIndex]
@@ -1740,7 +1742,7 @@ class MethodMirrorImpl extends _DataCaching implements MethodMirror {
   }
 
   @override
-  String get constructorName => isConstructor ? _name : "";
+  String get constructorName => isConstructor ? _name : '';
 
   @override
   bool get isAbstract => (_descriptor & constants.abstractAttribute != 0);
@@ -1763,7 +1765,7 @@ class MethodMirrorImpl extends _DataCaching implements MethodMirror {
   @override
   bool get isOperator =>
       isRegularMethod &&
-      ["+", "-", "*", "/", "[", "<", ">", "=", "~", "%"].contains(_name[0]);
+      ['+', '-', '*', '/', '[', '<', '>', '=', '~', '%'].contains(_name[0]);
 
   @override
   bool get isPrivate => (_descriptor & constants.privateAttribute != 0);
@@ -1800,13 +1802,13 @@ class MethodMirrorImpl extends _DataCaching implements MethodMirror {
       (_descriptor & constants.genericReturnTypeAttribute != 0);
 
   @override
-  SourceLocation get location => throw UnsupportedError("location");
+  SourceLocation get location => throw UnsupportedError('location');
 
   @override
   List<Object> get metadata {
     if (_metadata == null) {
       throw NoSuchCapabilityError(
-          "Requesting metadata of method '$simpleName' without capability");
+          'Requesting metadata of method `$simpleName` without capability');
     }
     return _metadata;
   }
@@ -1815,7 +1817,7 @@ class MethodMirrorImpl extends _DataCaching implements MethodMirror {
   List<ParameterMirror> get parameters {
     if (!_supportsDeclarations(_reflector)) {
       throw NoSuchCapabilityError(
-          "Attempt to get `parameters` without `DeclarationsCapability`");
+          'Attempt to get `parameters` without `DeclarationsCapability`');
     }
     return _parameterIndices
         .map((int parameterIndex) => _data.parameterMirrors[parameterIndex])
@@ -1823,13 +1825,13 @@ class MethodMirrorImpl extends _DataCaching implements MethodMirror {
   }
 
   @override
-  String get qualifiedName => "${owner.qualifiedName}.$_name";
+  String get qualifiedName => '${owner.qualifiedName}.$_name';
 
   @override
   TypeMirror get returnType {
     if (_returnTypeIndex == NO_CAPABILITY_INDEX) {
       throw NoSuchCapabilityError(
-          "Requesting returnType of method '$simpleName' without capability");
+          'Requesting returnType of method `$simpleName` without capability');
     }
     if (_hasDynamicReturnType) return DynamicMirrorImpl();
     if (_hasVoidReturnType) return VoidMirrorImpl();
@@ -1839,7 +1841,7 @@ class MethodMirrorImpl extends _DataCaching implements MethodMirror {
               null, _reflectedTypeArgumentsOfReturnType)
           : _data.typeMirrors[_returnTypeIndex];
     }
-    throw unreachableError("Unexpected kind of returnType");
+    throw unreachableError('Unexpected kind of returnType');
   }
 
   @override
@@ -1849,8 +1851,8 @@ class MethodMirrorImpl extends _DataCaching implements MethodMirror {
   @override
   Type get reflectedReturnType {
     if (_reflectedReturnTypeIndex == NO_CAPABILITY_INDEX) {
-      throw NoSuchCapabilityError("Requesting reflectedReturnType of method "
-          "'$simpleName' without capability");
+      throw NoSuchCapabilityError('Requesting reflectedReturnType of method '
+          '`$simpleName` without capability');
     }
     return _data.types[_reflectedReturnTypeIndex];
   }
@@ -1869,7 +1871,7 @@ class MethodMirrorImpl extends _DataCaching implements MethodMirror {
 
   @override
   String get simpleName => isConstructor
-      ? (_name == '' ? "${owner.simpleName}" : "${owner.simpleName}.$_name")
+      ? (_name == '' ? '${owner.simpleName}' : '${owner.simpleName}.$_name')
       : _name;
 
   @override
@@ -1878,7 +1880,7 @@ class MethodMirrorImpl extends _DataCaching implements MethodMirror {
   void _setupParameterListInfo() {
     _numberOfPositionalParameters = 0;
     _numberOfOptionalPositionalParameters = 0;
-    _namesOfNamedParameters = Set<Symbol>();
+    _namesOfNamedParameters = <Symbol>{};
     for (ParameterMirrorImpl parameterMirror in parameters) {
       if (parameterMirror.isNamed) {
         _namesOfNamedParameters.add(parameterMirror._nameSymbol);
@@ -1940,7 +1942,7 @@ class MethodMirrorImpl extends _DataCaching implements MethodMirror {
   }
 
   @override
-  String toString() => "MethodMirrorImpl($qualifiedName)";
+  String toString() => 'MethodMirrorImpl($qualifiedName)';
 }
 
 abstract class ImplicitAccessorMirrorImpl extends _DataCaching
@@ -1971,7 +1973,7 @@ abstract class ImplicitAccessorMirrorImpl extends _DataCaching
   DeclarationMirror get owner => _variableMirror.owner;
 
   @override
-  String get constructorName => "";
+  String get constructorName => '';
 
   @override
   bool get isAbstract => false;
@@ -2010,7 +2012,7 @@ abstract class ImplicitAccessorMirrorImpl extends _DataCaching
   bool get isTopLevel => false;
 
   @override
-  SourceLocation get location => throw UnsupportedError("location");
+  SourceLocation get location => throw UnsupportedError('location');
 
   @override
   List<Object> get metadata => <Object>[];
@@ -2051,7 +2053,7 @@ class ImplicitGetterMirrorImpl extends ImplicitAccessorMirrorImpl {
   List<ParameterMirror> get parameters {
     if (!_supportsDeclarations(_reflector)) {
       throw NoSuchCapabilityError(
-          "Attempt to get `parameters` without `DeclarationsCapability`");
+          'Attempt to get `parameters` without `DeclarationsCapability`');
     }
     return <ParameterMirror>[];
   }
@@ -2063,7 +2065,7 @@ class ImplicitGetterMirrorImpl extends ImplicitAccessorMirrorImpl {
   String get simpleName => _variableMirror.simpleName;
 
   @override
-  String toString() => "ImplicitGetterMirrorImpl($qualifiedName)";
+  String toString() => 'ImplicitGetterMirrorImpl($qualifiedName)';
 }
 
 class ImplicitSetterMirrorImpl extends ImplicitAccessorMirrorImpl {
@@ -2095,7 +2097,7 @@ class ImplicitSetterMirrorImpl extends ImplicitAccessorMirrorImpl {
   List<ParameterMirror> get parameters {
     if (!_supportsDeclarations(_reflector)) {
       throw NoSuchCapabilityError(
-          "Attempt to get `parameters` without `DeclarationsCapability`");
+          'Attempt to get `parameters` without `DeclarationsCapability`');
     }
     return <ParameterMirror>[
       ParameterMirrorImpl(
@@ -2114,13 +2116,13 @@ class ImplicitSetterMirrorImpl extends ImplicitAccessorMirrorImpl {
   }
 
   @override
-  String get qualifiedName => "${_variableMirror.qualifiedName}=";
+  String get qualifiedName => '${_variableMirror.qualifiedName}=';
 
   @override
-  String get simpleName => "${_variableMirror.simpleName}=";
+  String get simpleName => '${_variableMirror.simpleName}=';
 
   @override
-  String toString() => "ImplicitSetterMirrorImpl($qualifiedName)";
+  String toString() => 'ImplicitSetterMirrorImpl($qualifiedName)';
 }
 
 abstract class VariableMirrorBase extends _DataCaching
@@ -2168,13 +2170,13 @@ abstract class VariableMirrorBase extends _DataCaching
       (_descriptor & constants.genericTypeAttribute != 0);
 
   @override
-  SourceLocation get location => throw UnsupportedError("location");
+  SourceLocation get location => throw UnsupportedError('location');
 
   @override
   List<Object> get metadata {
     if (_metadata == null) {
       throw NoSuchCapabilityError(
-          "Requesting metadata of field '$simpleName' without capability");
+          'Requesting metadata of field `$simpleName` without capability');
     }
     return _metadata;
   }
@@ -2183,17 +2185,17 @@ abstract class VariableMirrorBase extends _DataCaching
   String get simpleName => _name;
 
   @override
-  String get qualifiedName => "${owner.qualifiedName}.$_name";
+  String get qualifiedName => '${owner.qualifiedName}.$_name';
 
   @override
   TypeMirror get type {
     if (_classMirrorIndex == NO_CAPABILITY_INDEX) {
       if (!_supportsType(_reflector)) {
         throw NoSuchCapabilityError(
-            "Attempt to get `type` without `TypeCapability`");
+            'Attempt to get `type` without `TypeCapability`');
       }
       throw NoSuchCapabilityError(
-          "Attempt to get class mirror for un-marked class (type of '$_name')");
+          'Attempt to get class mirror for un-marked class (type of `$_name`)');
     }
     if (_isDynamic) return DynamicMirrorImpl();
     if (_isClassType) {
@@ -2204,7 +2206,7 @@ abstract class VariableMirrorBase extends _DataCaching
               _reflectedTypeArguments)
           : _data.typeMirrors[_classMirrorIndex];
     }
-    throw unreachableError("Unexpected kind of type");
+    throw unreachableError('Unexpected kind of type');
   }
 
   @override
@@ -2216,10 +2218,10 @@ abstract class VariableMirrorBase extends _DataCaching
     if (_reflectedTypeIndex == NO_CAPABILITY_INDEX) {
       if (!_supportsReflectedType(_reflector)) {
         throw NoSuchCapabilityError(
-            "Attempt to get `reflectedType` without `reflectedTypeCapability`");
+            'Attempt to get `reflectedType` without `reflectedTypeCapability`');
       }
       throw UnsupportedError(
-          "Attempt to get reflectedType without capability (of '$_name')");
+          'Attempt to get reflectedType without capability (of `$_name`)');
     }
     if (_isDynamic) return dynamic;
     return _data.types[_reflectedTypeIndex];
@@ -2250,8 +2252,8 @@ class VariableMirrorImpl extends VariableMirrorBase {
   DeclarationMirror get owner {
     if (_ownerIndex == NO_CAPABILITY_INDEX) {
       throw NoSuchCapabilityError(
-          "Trying to get owner of variable '$qualifiedName' "
-          "without capability");
+          'Trying to get owner of variable `$qualifiedName` '
+          'without capability');
     }
     return isTopLevel
         ? _data.libraryMirrors[_ownerIndex]
@@ -2315,7 +2317,7 @@ class ParameterMirrorImpl extends VariableMirrorBase
   bool get hasDefaultValue {
     if (!_supportsDeclarations(_reflector)) {
       throw NoSuchCapabilityError(
-          "Attempt to get `hasDefaultValue` without `DeclarationsCapability`");
+          'Attempt to get `hasDefaultValue` without `DeclarationsCapability`');
     }
     return (_descriptor & constants.hasDefaultValueAttribute != 0);
   }
@@ -2324,7 +2326,7 @@ class ParameterMirrorImpl extends VariableMirrorBase
   Object get defaultValue {
     if (!_supportsDeclarations(_reflector)) {
       throw NoSuchCapabilityError(
-          "Attempt to get `defaultValue` without `DeclarationsCapability`");
+          'Attempt to get `defaultValue` without `DeclarationsCapability`');
     }
     return _defaultValue;
   }
@@ -2392,7 +2394,7 @@ class DynamicMirrorImpl implements TypeMirror {
   Type get reflectedType => dynamic;
 
   @override
-  String get simpleName => "dynamic";
+  String get simpleName => 'dynamic';
 
   // TODO(eernst) implement: do as in 'dart:mirrors'.
   @override
@@ -2409,7 +2411,7 @@ class DynamicMirrorImpl implements TypeMirror {
   TypeMirror get originalDeclaration => this;
 
   @override
-  SourceLocation get location => throw UnsupportedError("location");
+  SourceLocation get location => throw UnsupportedError('location');
 
   // TODO(eernst) implement: We ought to check for the capability, which
   // means that we should have a `_reflector`, and then we should throw a
@@ -2454,10 +2456,10 @@ class VoidMirrorImpl implements TypeMirror {
 
   @override
   Type get reflectedType =>
-      throw UnsupportedError("Attempt to get the reflected type of `void`");
+      throw UnsupportedError('Attempt to get the reflected type of `void`');
 
   @override
-  String get simpleName => "void";
+  String get simpleName => 'void';
 
   // TODO(eernst) implement: do as in 'dart:mirrors'.
   @override
@@ -2474,7 +2476,7 @@ class VoidMirrorImpl implements TypeMirror {
   TypeMirror get originalDeclaration => this;
 
   @override
-  SourceLocation get location => throw UnsupportedError("location");
+  SourceLocation get location => throw UnsupportedError('location');
 
   // TODO(eernst) implement: We ought to check for the capability, which
   // means that we should have a `supportsTypeRelations` bool, and then we
@@ -2550,7 +2552,7 @@ abstract class ReflectableImpl extends ReflectableBase
     ClassMirror result = data[this].classMirrorForType(type);
     if (result == null || !_hasTypeCapability) {
       throw NoSuchCapabilityError(
-          "Reflecting on type '$type' without capability");
+          'Reflecting on type `$type` without capability');
     }
     return result;
   }
@@ -2559,8 +2561,8 @@ abstract class ReflectableImpl extends ReflectableBase
   LibraryMirror findLibrary(String libraryName) {
     ReflectorData reflectorData = data[this];
     if (reflectorData.libraryMirrors == null) {
-      throw NoSuchCapabilityError("Using 'findLibrary' without capability. "
-          "Try adding `libraryCapability`.");
+      throw NoSuchCapabilityError('Using `findLibrary` without capability. '
+          'Try adding `libraryCapability`.');
     }
     // The specification says that an exception shall be thrown if there
     // is anything other than one library with a matching name.
@@ -2574,11 +2576,11 @@ abstract class ReflectableImpl extends ReflectableBase
     }
     switch (matchCount) {
       case 0:
-        throw ArgumentError("No such library: $libraryName");
+        throw ArgumentError('No such library: $libraryName');
       case 1:
         return matchingLibrary;
       default:
-        throw ArgumentError("Ambiguous library name: $libraryName");
+        throw ArgumentError('Ambiguous library name: $libraryName');
     }
   }
 
@@ -2586,8 +2588,8 @@ abstract class ReflectableImpl extends ReflectableBase
   Map<Uri, LibraryMirror> get libraries {
     ReflectorData reflectorData = data[this];
     if (reflectorData.libraryMirrors == null) {
-      throw NoSuchCapabilityError("Using 'libraries' without capability. "
-          "Try adding `libraryCapability`.");
+      throw NoSuchCapabilityError('Using `libraries` without capability. '
+          'Try adding `libraryCapability`.');
     }
     Map<Uri, LibraryMirror> result = <Uri, LibraryMirror>{};
     for (LibraryMirror library in reflectorData.libraryMirrors) {
@@ -2611,12 +2613,12 @@ class FakeType implements Type {
   final String description;
 
   @override
-  String toString() => "Type($description)";
+  String toString() => 'Type($description)';
 }
 
-bool _isSetterName(String name) => name.endsWith("=");
+bool _isSetterName(String name) => name.endsWith('=');
 
-String _getterNameToSetterName(String name) => name + "=";
+String _getterNameToSetterName(String name) => name + '=';
 
 bool _supportsType(ReflectableImpl reflector) {
   return reflector.capabilities

--- a/lib/src/reflectable_class_constants.dart
+++ b/lib/src/reflectable_class_constants.dart
@@ -5,5 +5,5 @@
 /// Constants used to recognize the [Reflectable] class.
 library reflectable.src.reflectable_class_constants;
 
-const String name = "Reflectable"; // Update if renaming class!
-const String id = "4c5bb5484ffbe3f266cafa28ebc80a0efa78957e";
+const String name = 'Reflectable'; // Update if renaming class!
+const String id = '4c5bb5484ffbe3f266cafa28ebc80a0efa78957e';

--- a/lib/src/reflectable_errors.dart
+++ b/lib/src/reflectable_errors.dart
@@ -21,40 +21,40 @@ library reflectable.src.transformer_errors;
 /// purpose or they were the result of a lack of knowledge that
 /// such metadata will not have any effect.
 const String METADATA_NOT_DIRECT_SUBCLASS =
-    "Metadata has type Reflectable, but is not an instance of "
-    "a direct subclass of Reflectable";
+    'Metadata has type Reflectable, but is not an instance of '
+    'a direct subclass of Reflectable';
 
 /// It is a transformation time error to give an argument to the super
 /// constructor invocation in a subclass of Reflectable that is of
 /// a non-class type.
 const String SUPER_ARGUMENT_NON_CLASS =
-    "The super constructor invocation receives an argument whose"
-    " type '{type}' is not a class.";
+    'The super constructor invocation receives an argument whose'
+    ' type `{type}` is not a class.';
 
 /// It is a transformation time error to give an argument to the super
 /// constructor invocation in a subclass of Reflectable that is defined
 /// outside the library 'package:reflectable/capability.dart'.
 const String SUPER_ARGUMENT_WRONG_LIBRARY =
-    "The super constructor invocation receives an argument whose"
-    " type '{element}' is defined outside the library '{library}'.";
+    'The super constructor invocation receives an argument whose'
+    ' type `{element}` is defined outside the library `{library}`.';
 
 /// It is a transformation time error to give an argument to the super
 /// constructor invocation in a subclass of Reflectable that is non-const.
 const String SUPER_ARGUMENT_NON_CONST =
-    "The super constructor invocation receives an argument"
-    " which is not a constant.";
+    'The super constructor invocation receives an argument'
+    ' which is not a constant.';
 
 /// It is a transformation time error to use an enum as a reflector class.
-const String IS_ENUM = "Encountered a reflector class which is an enum.";
+const String IS_ENUM = 'Encountered a reflector class which is an enum.';
 
 /// Finds any template holes of the form {name} in [template] and replaces them
 /// with the corresponding value in [replacements].
 String applyTemplate(String template, Map<String, String> replacements) {
-  return template.replaceAllMapped(RegExp(r"{(.*?)}"), (Match match) {
-    String index = match.group(1);
-    String replacement = replacements[index];
+  return template.replaceAllMapped(RegExp(r'{(.*?)}'), (Match match) {
+    var index = match.group(1);
+    var replacement = replacements[index];
     if (replacement == null) {
-      throw ArgumentError("Missing template replacement for $index");
+      throw ArgumentError('Missing template replacement for $index');
     }
     return replacements[index];
   });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ homepage: https://www.github.com/dart-lang/reflectable
 environment:
   sdk: '>=2.3.0 <3.0.0'
 dependencies:
-  analyzer: '>=0.36.0 <0.39.0'
+  analyzer: '>=0.36.0 <0.40.0'
   build: ^1.2.0
   build_resolvers: ^1.2.0
   build_config: ^0.4.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: reflectable
-version: 2.2.0
+version: 2.2.1
 description: >
   Reflection support based on code generation, using 'capabilities' to
   specify which operations to support, on which objects.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ homepage: https://www.github.com/dart-lang/reflectable
 environment:
   sdk: '>=2.3.0 <3.0.0'
 dependencies:
-  analyzer: '>=0.36.0 <0.40.0'
+  analyzer: '>=0.39.0 <0.40.0'
   build: ^1.2.0
   build_resolvers: ^1.2.0
   build_config: ^0.4.0


### PR DESCRIPTION
This PR changes many parts of the code in order to satisfy new linter requirements. In particular, it uses literal strings with single quotes whenever possible; it omits a number of type annotations on local variables (and introduces `ignore_for_file: omit_local_variable_type` in a couple of libraries, based on the judgment that the value of the type annotations for the reader of the code justifies keeping them).

The generated code now also contains a couple of `ignore_for_file` directives, such that the generated code does not get penalized for repeating structures from the target program (e.g., if a default value is `"a" + " string"` then we will copy that expression rather than simplifying it to `"a string"`, which will cause a linter complaint on the generated code).

Also, an actual bug was detected and fixed: The generation of code dealing with named parameters of constructors (supporting `myClassMirror.newInstance(...)`) relied on two lists having the same order. Turns out that the order may not be the same (at least with the new analyzer), so we are now looking up the name of the parameter at each index.

The resulting package has a new version number, 2.2.1, such that we can publish it.