### PR TITLE
Removed author field from pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,6 @@ version: 2.2.1
 description: >
   Reflection support based on code generation, using 'capabilities' to
   specify which operations to support, on which objects.
-author: Dart Team <misc@dartlang.org>
 homepage: https://www.github.com/dart-lang/reflectable
 environment:
   sdk: '>=2.3.0 <3.0.0'


### PR DESCRIPTION
Tiny fix, only deletes 'author' field from pubspec.yaml (it is no longer recommended to have this field).