### PR TITLE
Adjusted dependencies to avoid the breaking constructor signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.2.1+1
+
+* Restricting analyzer version to <= 0.39.3, because 0.39.3 contains a
+  breaking change in the parameter list of a constructor.
+
 ## 2.2.1
 
 * Fix a bug concerned with the ordering of named parameters in a constructor

--- a/lib/src/builder_implementation.dart
+++ b/lib/src/builder_implementation.dart
@@ -3863,8 +3863,8 @@ class BuilderImplementation {
     // users cannot write their own capability classes).
     if (dartType.element is! ClassElement) {
       await _severe(
-          errors.applyTemplate(
-              errors.SUPER_ARGUMENT_NON_CLASS, {'type': dartType.displayName}),
+          errors.applyTemplate(errors.SUPER_ARGUMENT_NON_CLASS,
+              {'type': dartType.getDisplayString()}),
           dartType.element);
       return ec.invokingCapability; // Error default.
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: reflectable
-version: 2.2.1
+version: 2.2.1+1
 description: >
   Reflection support based on code generation, using 'capabilities' to
   specify which operations to support, on which objects.
@@ -7,7 +7,7 @@ homepage: https://www.github.com/dart-lang/reflectable
 environment:
   sdk: '>=2.3.0 <3.0.0'
 dependencies:
-  analyzer: '>=0.39.0 <0.40.0'
+  analyzer: '>=0.39.0 <=0.39.3'
   build: ^1.2.0
   build_resolvers: ^1.2.0
   build_config: ^0.4.0


### PR DESCRIPTION
This is just a temporary fix for issue #194, which is that reflectable breaks because the analyzer requires a new and different list of parameters for `InterfaceTypeImpl` construction. This CL just restricts the version of the analyzer.

The real solution is to pass the arguments as required for the invocations of the `InterfaceTypeImpl` constructor call, which will be done in a separate CL.

It may seem even better to avoid dependencies on `InterfaceTypeImpl` in the first place, but that may not be very helpful because we would then have to write a whole parallel hierarchy for a class hierarchy in the analyzer, and use these wrappers everywhere.

PS: This CL is intended to be published as version 2.2.1+1. This version _will_ be needed: If a client can use an analyzer with version '>=0.39.0 <=0.39.3' but pub chooses analyzer 0.39.4 and reflectable 2.2.1 then the analyzer will have an incompatible constructor signature for `InterfaceTypeImpl` and 'builder_implementation' doesn't compile. With reflectable 2.2.1+1, pub can use any analyzer '>=0.39.0 <=0.39.3', and that pair works; and clients that do allow (or require) analyzer 0.39.4 or higher can use reflectable 2.2.1+2 (cf. #196), which is again a working pair.