### PR TITLE
Adjust usage of InterfaceTypeImpl constructor to match analyzer 0.39.4 and up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.1+2
+
+* Update reflectable to work with analyzer 0.39.4 and up to 0.40.0.
+
 ## 2.2.1+1
 
 * Restricting analyzer version to <= 0.39.3, because 0.39.3 contains a

--- a/lib/src/builder_implementation.dart
+++ b/lib/src/builder_implementation.dart
@@ -1856,7 +1856,7 @@ class _ReflectorDomain {
       [Set<String> typeVariablesInScope]) {
     if (type is TypeParameterType &&
         (typeVariablesInScope == null ||
-            !typeVariablesInScope.contains(type.name))) {
+            !typeVariablesInScope.contains(type.getDisplayString()))) {
       return false;
     }
     if (type is InterfaceType) {
@@ -1993,8 +1993,8 @@ class _ReflectorDomain {
       }
     } else if (dartType is TypeParameterType &&
         typeVariablesInScope != null &&
-        typeVariablesInScope.contains(dartType.name)) {
-      return dartType.name;
+        typeVariablesInScope.contains(dartType.getDisplayString())) {
+      return dartType.getDisplayString();
     } else {
       return fail();
     }
@@ -5204,14 +5204,20 @@ class MixinApplication implements ClassElement {
   // service than leaving this method unimplemented. We are then allowed to
   // take one more step, which may be enough.
   @override
-  InterfaceType get type => InterfaceTypeImpl(this);
+  InterfaceType get type => InterfaceTypeImpl(
+      element: this,
+      typeArguments: [],
+      nullabilitySuffix: NullabilitySuffix.star);
 
   @override
   InterfaceType instantiate({
     List<DartType> typeArguments,
     NullabilitySuffix nullabilitySuffix,
   }) =>
-      InterfaceTypeImpl(this);
+      InterfaceTypeImpl(
+          element: this,
+          typeArguments: typeArguments,
+          nullabilitySuffix: nullabilitySuffix);
 
   @override
   InterfaceType get supertype {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: reflectable
-version: 2.2.1+1
+version: 2.2.1+2
 description: >
   Reflection support based on code generation, using 'capabilities' to
   specify which operations to support, on which objects.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://www.github.com/dart-lang/reflectable
 environment:
   sdk: '>=2.3.0 <3.0.0'
 dependencies:
-  analyzer: '>=0.39.0 <=0.39.3'
+  analyzer: '>=0.39.4 <=0.39.4'
   build: ^1.2.0
   build_resolvers: ^1.2.0
   build_config: ^0.4.0


### PR DESCRIPTION
This CL changes the invocations of the `InterfaceTypeImpl` in 'builder_implementation.dart' such that it compiles with analyzer 0.39.4.

However, the `MixinApplication` class does not model type arguments and type parameters properly, and there is no underlying model of this in the analyzer (because it doesn't model the classes created by mixin application directly). The language specification also does not make it explicit how exactly to deal with type parameters in a mixin application. So maybe we should change 'builder_implementation' to raise an error in some additional cases, and maybe we could then avoid calling this constructor at all. (As far as I remember, we needed to support `type`, but we could revisit that.)

The point around type parameters is that with `class A<X, Y> extends B<int, X> with M<List<X>> {}`, it is reasonable to say that `B<int, X> with M<List<X>>` is a class that accepts 1 type argument (named `X`), with a bound which is such that `B<int, X>` and `M<List<X>>` are both regular-bounded. But we could also say that `B<int, X> with M<List<X>>` accepts two type arguments, because that's what `A` is capable of providing. The ordering is also unspecified (so the mixin application might accept `X, Y` or it might accept `Y, X`).

This matters because `MixinApplication` currently claims to have the empty list of type parameters. Similarly, this CL uses the empty list of type arguments as the default argument list when such a default is needed in the implementation of the `type` getter.

So there are several issues in the code touched by this CL that we may address now, or we may leave it as issues which are known, but currently not causing any known failures.

@sigurdm, WDYT?