### PR TITLE
Added lint exception about implementation_imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.2
+
+* Generate code which will not cause `implementation_imports` diagnostics.
+
 ## 2.2.1+2
 
 * Update reflectable to work with analyzer 0.39.4 and up to 0.40.0.

--- a/lib/src/builder_implementation.dart
+++ b/lib/src/builder_implementation.dart
@@ -4106,9 +4106,10 @@ class BuilderImplementation {
 import 'dart:core';
 ${imports.join('\n')}
 
-// ignore_for_file: unnecessary_const
-// ignore_for_file: prefer_collection_literals
 // ignore_for_file: prefer_adjacent_string_concatenation
+// ignore_for_file: prefer_collection_literals
+// ignore_for_file: unnecessary_const
+// ignore_for_file: implementation_imports
 
 // ignore:unused_import
 import 'package:reflectable/mirrors.dart' as m;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: reflectable
-version: 2.2.1+2
+version: 2.2.2
 description: >
   Reflection support based on code generation, using 'capabilities' to
   specify which operations to support, on which objects.


### PR DESCRIPTION
Some usages of reflectable give rise to `implementation_imports` messages, cf. #203. Given that reflectable is intended to be able to import any library which contains a declaration that the developer has requested reflection support for, it seems reasonable to say that the generated code should be allowed to violate this lint without complaints. So this PR adds an `ignore_for_file` directive to get that effect.
