### PR TITLE
Update analyzer; work around sync* getter issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.2.5
+
+* Update dependencies. In particular, analyzer can now be 0.39.10.
+  Handle issue with `sync*` functions, cf. issue #210.
+
 ## 2.2.4
 
 * Eliminate dependency on package `package_resolver` (which is deprecated).
@@ -12,7 +17,7 @@
 
 ## 2.2.1+2
 
-* Update reflectable to work with analyzer 0.39.4 and up to 0.40.0.
+* Update reflectable to work with analyzer 0.39.4.
 
 ## 2.2.1+1
 

--- a/lib/reflectable_builder.dart
+++ b/lib/reflectable_builder.dart
@@ -55,7 +55,7 @@ Future<BuildResult> reflectableBuild(List<String> arguments) async {
     var builders = <BuilderApplication>[
       applyToRoot(builder, generateFor: InputSet(include: arguments))
     ];
-    var packageGraph = PackageGraph.forThisPackage();
+    var packageGraph = await PackageGraph.forThisPackage();
     var environment = OverrideableEnvironment(IOEnvironment(packageGraph));
     var buildOptions = await BuildOptions.create(
       LogSubscription(environment),

--- a/lib/src/builder_implementation.dart
+++ b/lib/src/builder_implementation.dart
@@ -923,7 +923,7 @@ class _ReflectorDomain {
       var classesToAdd = <ClassElement>{};
       ClassElement anyClassElement;
       for (ClassElement classElement in await classes) {
-        if (_typeForReflectable(classElement).isObject) {
+        if (_typeForReflectable(classElement).isDartCoreObject) {
           hasObject = true;
           objectClassElement = classElement;
           break;
@@ -944,7 +944,7 @@ class _ReflectorDomain {
         }
       }
       if (mustHaveObject && !hasObject) {
-        while (!_typeForReflectable(anyClassElement).isObject) {
+        while (!_typeForReflectable(anyClassElement).isDartCoreObject) {
           anyClassElement = anyClassElement.supertype.element;
         }
         objectClassElement = anyClassElement;
@@ -1397,7 +1397,7 @@ class _ReflectorDomain {
       // 'dart:mirrors'. Other superclasses use `NO_CAPABILITY_INDEX` to
       // indicate missing support.
       superclassIndex = (classElement is! MixinApplication &&
-              _typeForReflectable(classElement).isObject)
+              _typeForReflectable(classElement).isDartCoreObject)
           ? 'null'
           : ((await classes).contains(superclass))
               ? '${(await classes).indexOf(superclass)}'
@@ -4522,7 +4522,8 @@ Future<String> _extractConstantCode(
             'needed for expression $expression');
         return '';
       }
-      LibraryElement libraryOfConstructor = expression.staticElement.library;
+      LibraryElement libraryOfConstructor =
+          expression.constructorName.staticElement.library;
       if (await _isImportableLibrary(
           libraryOfConstructor, generatedLibraryId, resolver)) {
         importCollector._addLibrary(libraryOfConstructor);

--- a/lib/src/builder_implementation.dart
+++ b/lib/src/builder_implementation.dart
@@ -1061,11 +1061,11 @@ class _ReflectorDomain {
             typedefs,
             reflectedTypeRequested));
       }
-      Iterable<String> membersList = () sync* {
-        yield* topLevelVariablesList;
-        yield* fieldsList;
-        yield* methodsList;
-      }();
+      Iterable<String> membersList = [
+        ...topLevelVariablesList,
+        ...fieldsList,
+        ...methodsList,
+      ];
       membersCode = _formatAsList('m.DeclarationMirror', membersList);
     }
 
@@ -1354,10 +1354,7 @@ class _ReflectorDomain {
     });
 
     String declarationsCode = _capabilities._impliesDeclarations
-        ? _formatAsConstList('int', () sync* {
-            yield* fieldsIndices;
-            yield* methodsIndices;
-          }())
+        ? _formatAsConstList('int', [...fieldsIndices, ...methodsIndices])
         : 'const <int>[${constants.NO_CAPABILITY_INDEX}]';
 
     // All instance members belong to the behavioral interface, so they
@@ -1490,10 +1487,10 @@ class _ReflectorDomain {
 
     String parameterListShapesCode = 'null';
     if (_capabilities._impliesParameterListShapes) {
-      Iterable<ExecutableElement> membersList = () sync* {
-        yield* classDomain._instanceMembers;
-        yield* classDomain._staticMembers;
-      }();
+      Iterable<ExecutableElement> membersList = [
+        ...classDomain._instanceMembers,
+        ...classDomain._staticMembers,
+      ];
       parameterListShapesCode =
           _formatAsMap(membersList.map((ExecutableElement element) {
         ParameterListShape shape = parameterListShapeOf[element];
@@ -2170,10 +2167,10 @@ class _ReflectorDomain {
 
     String declarationsCode = 'const <int>[${constants.NO_CAPABILITY_INDEX}]';
     if (_capabilities._impliesDeclarations) {
-      Iterable<int> declarationsIndices = () sync* {
-        yield* variableIndices;
-        yield* methodIndices;
-      }();
+      Iterable<int> declarationsIndices = [
+        ...variableIndices,
+        ...methodIndices,
+      ];
       declarationsCode = _formatAsConstList('int', declarationsIndices);
     }
 
@@ -2657,10 +2654,10 @@ class _LibraryDomain {
   /// setters, and omits fields; in other words, it provides the
   /// behavioral point of view on the class. Also note that this is not
   /// the same semantics as that of `declarations` in [ClassMirror].
-  Iterable<ExecutableElement> get _declarations sync* {
-    yield* _declaredFunctions;
-    yield* _accessors;
-  }
+  Iterable<ExecutableElement> get _declarations => [
+        ..._declaredFunctions,
+        ..._accessors,
+      ];
 
   @override
   String toString() {
@@ -2758,12 +2755,12 @@ class _ClassDomain {
   /// setters, and omits fields; in other words, it provides the
   /// behavioral point of view on the class. Also note that this is not
   /// the same semantics as that of `declarations` in [ClassMirror].
-  Iterable<ExecutableElement> get _declarations sync* {
-    // TODO(sigurdm) feature: Include type variables (if we keep them).
-    yield* _declaredMethods;
-    yield* _accessors;
-    yield* _constructors;
-  }
+  Iterable<ExecutableElement> get _declarations => [
+        // TODO(sigurdm) feature: Include type variables (if we keep them).
+        ..._declaredMethods,
+        ..._accessors,
+        ..._constructors,
+      ];
 
   /// Finds all instance members by going through the class hierarchy.
   Iterable<ExecutableElement> get _instanceMembers {

--- a/lib/src/builder_implementation.dart
+++ b/lib/src/builder_implementation.dart
@@ -2658,8 +2658,8 @@ class _LibraryDomain {
   /// behavioral point of view on the class. Also note that this is not
   /// the same semantics as that of `declarations` in [ClassMirror].
   Iterable<ExecutableElement> get _declarations sync* {
-    for (var f in _declaredFunctions) yield f;
-    for (var a in _accessors) yield a;
+    yield* _declaredFunctions;
+    yield* _accessors;
   }
 
   @override
@@ -5033,10 +5033,12 @@ _LibraryDomain _createLibraryDomain(
       _extractDeclaredFunctions(domain._resolver, library, domain._capabilities)
           .toList();
   Iterable<PropertyAccessorElement> accessorsOfLibrary =
-      _extractLibraryAccessors(domain._resolver, library, domain._capabilities);
+      _extractLibraryAccessors(domain._resolver, library, domain._capabilities)
+          .toList();
   Iterable<ParameterElement> declaredParametersOfLibrary =
       _extractDeclaredFunctionParameters(
-          domain._resolver, declaredFunctionsOfLibrary, accessorsOfLibrary);
+              domain._resolver, declaredFunctionsOfLibrary, accessorsOfLibrary)
+          .toList();
   return _LibraryDomain(
       library,
       declaredVariablesOfLibrary,

--- a/lib/src/builder_implementation.dart
+++ b/lib/src/builder_implementation.dart
@@ -2658,8 +2658,8 @@ class _LibraryDomain {
   /// behavioral point of view on the class. Also note that this is not
   /// the same semantics as that of `declarations` in [ClassMirror].
   Iterable<ExecutableElement> get _declarations sync* {
-    yield* _declaredFunctions;
-    yield* _accessors;
+    for (var f in _declaredFunctions) yield f;
+    for (var a in _accessors) yield a;
   }
 
   @override
@@ -2758,13 +2758,11 @@ class _ClassDomain {
   /// setters, and omits fields; in other words, it provides the
   /// behavioral point of view on the class. Also note that this is not
   /// the same semantics as that of `declarations` in [ClassMirror].
-  Iterable<ExecutableElement> get _declarations {
+  Iterable<ExecutableElement> get _declarations sync* {
     // TODO(sigurdm) feature: Include type variables (if we keep them).
-    return () sync* {
-      yield* _declaredMethods;
-      yield* _accessors;
-      yield* _constructors;
-    }();
+    yield* _declaredMethods;
+    yield* _accessors;
+    yield* _constructors;
   }
 
   /// Finds all instance members by going through the class hierarchy.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,11 +8,11 @@ environment:
   sdk: '>=2.3.0 <3.0.0'
 dependencies:
   analyzer: '>=0.39.4 <=0.39.10'
-  build: ^1.2.0
-  build_resolvers: ^1.2.0
+  build: ^1.3.0
+  build_resolvers: ^1.3.0
   build_config: ^0.4.0
-  build_runner: ^1.7.0
-  build_runner_core: ^4.1.0
+  build_runner: ^1.10.0
+  build_runner_core: ^5.2.0
   dart_style: ^1.3.0
   glob: ^1.2.0
   logging: ^0.11.0
@@ -20,6 +20,6 @@ dependencies:
   path: ^1.6.0
   source_span: ^1.5.0
 dev_dependencies:
-  build_test: ^0.10.0
+  build_test: ^1.2.0
   pedantic: ^1.8.0
   test: ^1.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: reflectable
-version: 2.2.4
+version: 2.2.5
 description: >
   Reflection support based on code generation, using 'capabilities' to
   specify which operations to support, on which objects.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://www.github.com/dart-lang/reflectable
 environment:
   sdk: '>=2.3.0 <3.0.0'
 dependencies:
-  analyzer: '>=0.39.4 <=0.39.4'
+  analyzer: '>=0.39.4 <=0.39.10'
   build: ^1.2.0
   build_resolvers: ^1.2.0
   build_config: ^0.4.0


### PR DESCRIPTION
Cf. #210 and https://github.com/dart-lang/sdk/issues/42347, there is an issue with `sync*` getters, This PR works around that issue, and upgrades the analyzer version to 0.39.10.

Note that the "workaround" is adding `.toList()` at a point where several other similar expressions already have `.toList()`, which seems to be a reasonable approach anyway, and probably a bit faster. So there is no need to undo it when dart-lang/sdk#42347 is handled.