### PR TITLE
fix for issue 354

### DIFF
--- a/packages/reflectable_builder/lib/src/builder_implementation.dart
+++ b/packages/reflectable_builder/lib/src/builder_implementation.dart
@@ -5593,7 +5593,7 @@ CompilationUnit? _definingCompilationUnit(
 
 // Helper for _extractMetadataCode.
 NodeList<Annotation>? _getLibraryMetadata(CompilationUnit? unit) {
-  if (unit != null) {
+  if (unit != null && unit.directives.isNotEmpty) {
     Directive directive = unit.directives[0];
     if (directive is LibraryDirective) {
       return directive.metadata;


### PR DESCRIPTION
Fix, if you want it, for issue 354 Exception in _getLibraryMetadata while running reflectable_builder

Just adding the length check for the directives list.