### PR TITLE
Update dependency to use analyzer 13

### DIFF
--- a/packages/reflectable/CHANGELOG.md
+++ b/packages/reflectable/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.2.3
+
+- Update dependency to use analyzer ^12.0.0.
+
 ## 5.2.2
 
 - Update the language version to 3.12.

--- a/packages/reflectable/CHANGELOG.md
+++ b/packages/reflectable/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 5.2.3
 
-- Update dependency to use analyzer ^12.0.0.
+- Update dependency to use analyzer ^13.0.0.
 
 ## 5.2.2
 

--- a/packages/reflectable/pubspec.yaml
+++ b/packages/reflectable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: reflectable
-version: 5.2.2
+version: 5.2.3
 description: >
   Reflection support based on code generation, using 'capabilities' to
   specify which operations to support, on which objects. This is the

--- a/packages/reflectable_builder/CHANGELOG.md
+++ b/packages/reflectable_builder/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.2.3
 
-- Migrate the code generator to use analyzer version ^12.0.0.
+- Migrate the code generator to use analyzer version ^13.0.0.
 
 ## 1.2.2
 

--- a/packages/reflectable_builder/CHANGELOG.md
+++ b/packages/reflectable_builder/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.3
+
+- Migrate the code generator to use analyzer version ^12.0.0.
+
 ## 1.2.2
 
 - Upgrade the language version to 3.12. Migrate the code generator to

--- a/packages/reflectable_builder/example/example.dart
+++ b/packages/reflectable_builder/example/example.dart
@@ -18,7 +18,7 @@ const myReflectable = MyReflectable();
 class A {
   int arg0() => 42;
   int arg1(int x) => x - 42;
-  int arg1to3(int x, int y, [int z = 0, w]) => x + y + z * 42;
+  int arg1to3(int x, int y, [int z = 0, String? w]) => x + y + z * 42;
   int argNamed(int x, int y, {int z = 42}) => x + y - z;
   int operator +(int x) => 42 + x;
   int operator [](int x) => 42 + x;
@@ -33,7 +33,7 @@ class A {
 
   static int noArguments() => 42;
   static int oneArgument(int x) => x - 42;
-  static int optionalArguments(int x, int y, [int z = 0, int? w]) =>
+  static int optionalArguments(int x, int y, [int z = 0, String? w]) =>
       x + y + z * 42;
   static int namedArguments(int x, int y, {int z = 42}) => x + y - z;
 }

--- a/packages/reflectable_builder/lib/src/builder_implementation.dart
+++ b/packages/reflectable_builder/lib/src/builder_implementation.dart
@@ -2731,15 +2731,15 @@ class _ReflectorDomain {
             as FormalParameter?;
     // The node can be null because the declaration is synthetic, e.g.,
     // the parameter of an induced setter; they have no default value.
-    if (parameterNode is DefaultFormalParameter &&
-        parameterNode.defaultValue != null) {
+    FormalParameterDefaultClause? defaultClause = parameterNode?.defaultClause;
+    if (defaultClause != null) {
       return await _extractConstantCode(
-        parameterNode.defaultValue!,
+        defaultClause.value,
         importCollector,
         _generatedLibraryId,
         _resolver,
       );
-    } else if (parameterElement is DefaultFormalParameter) {
+    } else {
       Expression? defaultValue = parameterElement.constantInitializer;
       if (defaultValue != null) {
         return await _extractConstantCode(
@@ -4819,9 +4819,10 @@ class BuilderImplementation {
       // Subcase: `super(..)` where 0..k arguments are accepted for some
       // k that we need not worry about here.
       var capabilities = <ec.ReflectCapability>[];
-      for (Expression argument in superInvocation.argumentList.arguments) {
+      for (Argument argument in superInvocation.argumentList.arguments) {
+        Expression expression = argument is NamedArgument ? argument.argumentExpression : argument as Expression;
         ec.ReflectCapability? currentCapability =
-            await capabilityOfCollectionElement(argument);
+            await capabilityOfCollectionElement(expression);
         if (currentCapability != null) capabilities.add(currentCapability);
       }
       return _Capabilities(capabilities);
@@ -4829,9 +4830,9 @@ class BuilderImplementation {
     assert(superInvocationConstructorName.name == 'fromList');
 
     // Subcase: `super.fromList(const <..>[..])`.
-    NodeList<Expression> arguments = superInvocation.argumentList.arguments;
+    NodeList<Argument> arguments = superInvocation.argumentList.arguments;
     assert(arguments.length == 1);
-    Expression listLiteral = arguments[0];
+    Expression listLiteral = arguments[0] as Expression;
     var capabilities = <ec.ReflectCapability>[];
     if (listLiteral is! ListLiteral) {
       await _severe(
@@ -5296,7 +5297,7 @@ String _formatAsMap(Iterable parts) => '{${parts.join(', ')}}';
 /// value when evaluated in the generated file as the given [expression]
 /// would evaluate to in [originatingLibrary].
 Future<String> _extractConstantCode(
-  Expression expression,
+  Argument expression,
   _ImportCollector importCollector,
   AssetId generatedLibraryId,
   Resolver resolver,
@@ -5317,7 +5318,7 @@ Future<String> _extractConstantCode(
     }
   }
 
-  Future<String> helper(Expression expression) async {
+  Future<String> helper(Argument expression) async {
     if (expression is ListLiteral) {
       var elements = <String>[];
       for (CollectionElement collectionElement in expression.elements) {
@@ -5427,7 +5428,7 @@ Future<String> _extractConstantCode(
         String prefix = importCollector._getPrefix(libraryOfConstructor);
         // TODO(sigurdm) implement: Named arguments.
         var argumentList = <String>[];
-        for (Expression argument in expression.argumentList.arguments) {
+        for (Argument argument in expression.argumentList.arguments) {
           argumentList.add(await helper(argument));
         }
         String arguments = argumentList.join(', ');
@@ -5531,19 +5532,19 @@ Future<String> _extractConstantCode(
       // We only handle 'identical(a, b)'.
       assert(expression.target == null);
       assert(expression.methodName.token.lexeme == 'identical');
-      NodeList<Expression> arguments = expression.argumentList.arguments;
+      NodeList<Argument> arguments = expression.argumentList.arguments;
       assert(arguments.length == 2);
       String a = await helper(arguments[0]);
       String b = await helper(arguments[1]);
       return 'identical($a, $b)';
-    } else if (expression is NamedExpression) {
+    } else if (expression is NamedArgument) {
       String value = await _extractConstantCode(
-        expression.expression,
+        expression.argumentExpression,
         importCollector,
         generatedLibraryId,
         resolver,
       );
-      return '${expression.name} $value';
+      return '${expression.name.lexeme}: $value';
     } else if (expression is FunctionReference) {
       String function = await _extractConstantCode(
         expression.function,
@@ -5738,7 +5739,7 @@ Future<String> _extractMetadataCode(
         element,
       );
       var argumentList = <String>[];
-      for (Expression argument in annotationNodeArguments.arguments) {
+      for (Argument argument in annotationNodeArguments.arguments) {
         argumentList.add(
           await _extractConstantCode(
             argument,

--- a/packages/reflectable_builder/pubspec.yaml
+++ b/packages/reflectable_builder/pubspec.yaml
@@ -1,5 +1,5 @@
 name: reflectable_builder
-version: 1.2.2
+version: 1.2.3
 description: >
   Reflection support based on code generation, using 'capabilities' to
   specify which operations to support, on which objects. This is the
@@ -9,7 +9,7 @@ environment:
   sdk: ^3.12.0
 resolution: workspace
 dependencies:
-  analyzer: ^11.0.0
+  analyzer: ^12.0.0
   build: ^4.0.0
   dart_style: ^3.0.0
   pub_semver: ^2.2.0

--- a/packages/reflectable_builder/pubspec.yaml
+++ b/packages/reflectable_builder/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ^3.12.0
 resolution: workspace
 dependencies:
-  analyzer: ^12.0.0
+  analyzer: ^13.0.0
   build: ^4.0.0
   dart_style: ^3.0.0
   pub_semver: ^2.2.0


### PR DESCRIPTION
This PR changes the dependencies in the reflectable packages to use analyzer ^13.0.0 and migrates the code generator accordingly. In particular:

Analyzer ^13.0.0 removes the class `DefaultFormalParameter`. Default values are now handled via a property on `FormalParameter`. Old approach: Check if a parameter node is a `DefaultFormalParameter`, access its `defaultValue`. New approach: Check the `defaultClause` property on a `FormalParameter` or `RegularFormalParameter` and access its `value`.

Similarly, the class `NamedExpression` has been removed and replaced by `NamedArgument`, in order to model named arguments in an `ArgumentList`. Old approach: Use `expression is NamedExpression` and access `expression.name` and `expression.expression`. New approach: Use `expression is NamedArgument` and access `expression.name.lexeme` to get the label name and `expression.argumentExpression` to get the value.

Finally, the `arguments` property of `ArgumentList` now returns a `NodeList<Argument>` instead of a `NodeList<Expression>`. Various loops have been updated to use the new types.

This PR also prepares `reflectable` for a release as v5.2.3 and `reflectable_builder` as v1.2.3. Version v5.2.3 of `reflectable` doesn't actually change anything other than the version, but I'd like to allow all usages of `reflectable` and `reflectable_builder` to remain in sync with respect to the version number such that developers can always update those two IDs together (e.g., from 5.2.2 to 5.2.3 along with 1.2.2 to 1.2.3, simultaneously).

Finally, this PR fixes a bug in 'example.dart' (where a lint asked for a type annotation on a parameter, but the type annotation which was added was wrong).