### PR TITLE
Add dependabot configuration to packages reflectable and reflectable_builder

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,6 @@
 version: 2
 updates:
-  # Configuration for packages/reflectable
   - package-ecosystem: "pub"
-    directory: "/packages/reflectable"
+    directory: "/"
     schedule:
       interval: "weekly"
-
-  # Configuration for packages/reflectable_builder
-  - package-ecosystem: "pub"
-    directory: "/packages/reflectable_builder"
-    schedule:
-      interval: "weekly"
-
-  # No configuration for packages/test_reflectable:
-  # It is not published.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  # Configuration for packages/reflectable
+  - package-ecosystem: "pub"
+    directory: "/packages/reflectable"
+    schedule:
+      interval: "weekly"
+
+  # Configuration for packages/reflectable_builder
+  - package-ecosystem: "pub"
+    directory: "/packages/reflectable_builder"
+    schedule:
+      interval: "weekly"
+
+  # No configuration for packages/test_reflectable:
+  # It is not published.


### PR DESCRIPTION
This PR adds a dependabot configuration file to this repository, requesting version updating PRs for the packages such that they can more easily be kept up to date with respect to dependency updates.