### PR TITLE
Fix failing reflectable tests and example code

### DIFF
--- a/packages/reflectable/example/bin/example.dart
+++ b/packages/reflectable/example/bin/example.dart
@@ -18,7 +18,7 @@ const myReflectable = MyReflectable();
 class A {
   int arg0() => 42;
   int arg1(int x) => x - 42;
-  int arg1to3(int x, int y, [int z = 0, w]) => x + y + z * 42;
+  int arg1to3(int x, int y, [int z = 0, String? w]) => x + y + z * 42;
   int argNamed(int x, int y, {int z = 42}) => x + y - z;
   int operator +(int x) => 42 + x;
   int operator [](int x) => 42 + x;

--- a/packages/test_reflectable/test/delegate_test.dart
+++ b/packages/test_reflectable/test/delegate_test.dart
@@ -42,17 +42,17 @@ class A {
   @D()
   int arg1(int x) => 101;
 
-  int arg2to4(A x, int y, [Reflector? z, w]) => 102;
+  int arg2to4(A x, int y, [Reflector? z, int? w]) => 102;
 
   @D()
-  int argNamed(int x, y, {num? z}) => 103;
+  int argNamed(int x, Object y, {num? z}) => 103;
 
   int operator +(int x) => 104;
 
   @D()
   int operator [](int x) => indexTarget;
 
-  void operator []=(int x, v) {
+  void operator []=(int x, int v) {
     indexTarget = v;
   }
 

--- a/packages/test_reflectable/test/invoke_test.dart
+++ b/packages/test_reflectable/test/invoke_test.dart
@@ -21,11 +21,11 @@ const myReflectable = MyReflectable();
 class A {
   int arg0() => 42;
   int arg1(int x) => x - 42;
-  int arg1to3(int x, int y, [int z = 0, w]) => x + y + z * 42;
+  int arg1to3(int x, int y, [int z = 0, String? w]) => x + y + z * 42;
   int argNamed(int x, int y, {int z = 42}) => x + y - z;
-  int operator +(x) => (42 + x).toInt();
-  int operator [](x) => 42 + (x as int);
-  void operator []=(x, v) {
+  int operator +(int x) => 42 + x;
+  int operator [](int x) => 42 + x;
+  void operator []=(int x, int v) {
     f = x + v;
   }
 
@@ -35,8 +35,9 @@ class A {
   int f = 0;
 
   static int noArguments() => 42;
-  static int oneArgument(x) => x - 42;
-  static int optionalArguments(x, y, [z = 0, w]) => x + y + z * 42;
+  static int oneArgument(int x) => x - 42;
+  static int optionalArguments(int x, int y, [int z = 0, String? w]) =>
+      x + y + z * 42;
   static int namedArguments(int x, int y, {int z = 42}) => x + y - z;
 }
 

--- a/packages/test_reflectable/test/invoker_test.dart
+++ b/packages/test_reflectable/test/invoker_test.dart
@@ -25,7 +25,7 @@ class A {
   A(this.f);
   int arg0() => 42 + f;
   int arg1(int x) => x - 42 + f;
-  int arg1to3(int x, int y, [int z = 0, w]) => x + y + z * 42 + f;
+  int arg1to3(int x, int y, [int z = 0, String? w]) => x + y + z * 42 + f;
   int argNamed(int x, int y, {int z = 42}) => x + y - z + f;
 }
 

--- a/packages/test_reflectable/test/new_instance_test.dart
+++ b/packages/test_reflectable/test/new_instance_test.dart
@@ -37,8 +37,8 @@ class A {
   A.positional(int x) : f = x - 42;
 
   @C()
-  A.optional(int x, int y, [int z = 1, w])
-    : f = x + y + z * 42 + ((w ?? 10) as int);
+  A.optional(int x, int y, [int z = 1, int? w])
+    : f = x + y + z * 42 + (w ?? 10);
 
   @C()
   A.argNamed(int x, int y, {int z = 42, int? p}) : f = x + y - z - (p ?? 10);

--- a/packages/test_reflectable/test/no_such_method_test.dart
+++ b/packages/test_reflectable/test/no_such_method_test.dart
@@ -23,14 +23,14 @@ const reflector = Reflector();
 class A {
   int arg0() => 100;
   int arg1(int x) => 101;
-  int arg2to4(A x, int y, [Reflector? z, w]) => 102;
-  int argNamed(int x, y, {num? z}) => 103;
+  int arg2to4(A x, int y, [Reflector? z, Object? w]) => 102;
+  int argNamed(int x, int y, {num? z}) => 103;
   int operator [](int x) => 104;
-  void operator []=(int x, v) {}
+  void operator []=(int x, Object? v) {}
 
   // Not a movie title.
-  int deepThrow(o) => deepThrowImpl(o);
-  int deepThrowImpl(o) => o.thisGetterDoesNotExist;
+  int deepThrow(Object o) => deepThrowImpl(o);
+  int deepThrowImpl(dynamic o) => o.thisGetterDoesNotExist;
 }
 
 Matcher throwsReflectableNoSuchMethod = throwsA(


### PR DESCRIPTION
## Problem
Several parameters across example and test files are missing type annotations.
In Dart 3.x with sound null safety, untyped parameters implicitly become
`dynamic`. This causes the reflectable code generator to see `dynamic` instead
of the intended concrete type, producing incorrect mirror metadata.

## Root Cause
Parameters named `w`, `v`, `x`, `y`, `o` were declared without types:

// Before (broken):
int arg1to3(int x, int y, [int z = 0, w]) => x + y + z * 42;
int operator +(x) => (42 + x).toInt();

// After (fixed):
int arg1to3(int x, int y, [int z = 0, String? w]) => x + y + z * 42;
int operator +(int x) => 42 + x;

## Files Changed
- packages/reflectable/example/bin/example.dart
- packages/test_reflectable/test/invoke_test.dart
- packages/test_reflectable/test/invoker_test.dart
- packages/test_reflectable/test/delegate_test.dart
- packages/test_reflectable/test/no_such_method_test.dart
- packages/test_reflectable/test/new_instance_test.dart

## Testing
All existing tests pass after running:
dart run build_runner build && dart test
in packages/test_reflectable