### PR TITLE
Update dependencies to use analyzer ^14.0.0

### DIFF
--- a/packages/reflectable/CHANGELOG.md
+++ b/packages/reflectable/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.2.4
+
+- Update dependency to use analyzer ^14.0.0.
+
 ## 5.2.3
 
 - Update dependency to use analyzer ^13.0.0.

--- a/packages/reflectable/example/bin/example.dart
+++ b/packages/reflectable/example/bin/example.dart
@@ -33,7 +33,7 @@ class A {
 
   static int noArguments() => 42;
   static int oneArgument(int x) => x - 42;
-  static int optionalArguments(int x, int y, [int z = 0, int? w]) =>
+  static int optionalArguments(int x, int y, [int z = 0, String? w]) =>
       x + y + z * 42;
   static int namedArguments(int x, int y, {int z = 42}) => x + y - z;
 }

--- a/packages/reflectable/pubspec.yaml
+++ b/packages/reflectable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: reflectable
-version: 5.2.3
+version: 5.2.4
 description: >
   Reflection support based on code generation, using 'capabilities' to
   specify which operations to support, on which objects. This is the

--- a/packages/reflectable_builder/CHANGELOG.md
+++ b/packages/reflectable_builder/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.4
+
+- Update dependencies to use analyzer version ^14.0.0.
+
 ## 1.2.3
 
 - Migrate the code generator to use analyzer version ^13.0.0.

--- a/packages/reflectable_builder/lib/src/builder_implementation.dart
+++ b/packages/reflectable_builder/lib/src/builder_implementation.dart
@@ -4820,7 +4820,9 @@ class BuilderImplementation {
       // k that we need not worry about here.
       var capabilities = <ec.ReflectCapability>[];
       for (Argument argument in superInvocation.argumentList.arguments) {
-        Expression expression = argument is NamedArgument ? argument.argumentExpression : argument as Expression;
+        Expression expression = argument is NamedArgument
+            ? argument.argumentExpression
+            : argument as Expression;
         ec.ReflectCapability? currentCapability =
             await capabilityOfCollectionElement(expression);
         if (currentCapability != null) capabilities.add(currentCapability);
@@ -5252,7 +5254,7 @@ int _declarationDescriptor(ExecutableElement element) {
       result |= constants.redirectingConstructorAttribute;
     }
     if (element.isOriginImplicitDefault) result |= constants.syntheticAttribute;
-} else if (element is MethodElement) {
+  } else if (element is MethodElement) {
     result |= constants.method;
     handleReturnType(element);
     if (!element.isOriginDeclaration) result |= constants.syntheticAttribute;

--- a/packages/reflectable_builder/pubspec.yaml
+++ b/packages/reflectable_builder/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ^3.12.0
 resolution: workspace
 dependencies:
-  analyzer: ^13.0.0
+  analyzer: ^14.0.0
   build: ^4.0.0
   dart_style: ^3.0.0
   pub_semver: ^2.2.0

--- a/packages/reflectable_builder/pubspec.yaml
+++ b/packages/reflectable_builder/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   dart_style: ^3.0.0
   pub_semver: ^2.2.0
   path: ^1.9.0
-  reflectable: '>=5.2.0 <5.3.0'
+  reflectable: '>=5.2.4 <5.3.0'
 dev_dependencies:
   build_config: ^1.2.0
   build_runner: ^2.10.0

--- a/packages/reflectable_builder/pubspec.yaml
+++ b/packages/reflectable_builder/pubspec.yaml
@@ -1,5 +1,5 @@
 name: reflectable_builder
-version: 1.2.3
+version: 1.2.4
 description: >
   Reflection support based on code generation, using 'capabilities' to
   specify which operations to support, on which objects. This is the


### PR DESCRIPTION
This PR changes the dependencies of 'reflectable' and 'reflectable_builder' to use the most recent analyzer version. It corrects a parameter type in 'reflectable_builder/example' as well. It prepares 'reflectable' and 'reflectable_builder' to be published as version 5.2.4 and 1.2.4, respectively.